### PR TITLE
Added pixel ratio to FFmpegRead.cpp with correct formatting.

### DIFF
--- a/lib/tlIO/FFmpegRead.cpp
+++ b/lib/tlIO/FFmpegRead.cpp
@@ -412,6 +412,9 @@ namespace tl
                 imaging::Info videoInfo;
                 videoInfo.size.w = p.video.avCodecParameters[p.video.avStream]->width;
                 videoInfo.size.h = p.video.avCodecParameters[p.video.avStream]->height;
+                if ( p.video.avCodecParameters[p.video.avStream]->sample_aspect_ratio.den > 0 &&
+                     p.video.avCodecParameters[p.video.avStream]->sample_aspect_ratio.num > 0 )
+                    videoInfo.pixelAspectRatio = av_q2d( p.video.avCodecParameters[p.video.avStream]->sample_aspect_ratio );
                 videoInfo.layout.mirror.y = true;
 
                 p.video.avInputPixelFormat = static_cast<AVPixelFormat>(


### PR DESCRIPTION
Added pixel ratio to FFmpeg reader.  The pixel ratio is not yet used in the render pipeline.