### PR TITLE
Fixed local paths (ie. $PWD) or those starting with ./

### DIFF
--- a/lib/tlTimeline/Timeline.cpp
+++ b/lib/tlTimeline/Timeline.cpp
@@ -61,7 +61,8 @@ namespace tl
             file::Path out = file::Path(removeFileURLPrefix(url), options);
             if (!out.isAbsolute())
             {
-                out = file::Path(directory, out.get(), options);
+                if ( out.get().compare( 0, directory.size(), directory ) != 0 )
+                   out = file::Path(directory, out.get(), options);
             }
             return out;
         }


### PR DESCRIPTION
tlRender was choking when the path passed to the player was not absolute (ie. current directory) or started with a ./
