### PR TITLE
Added beginRaster() and endRaster() to draw text in raster coordinates.

### DIFF
--- a/lib/tlGL/Render.cpp
+++ b/lib/tlGL/Render.cpp
@@ -715,7 +715,7 @@ namespace tl
 
             p.shaders["display"].reset();
         }
-
+        
         void Render::begin(const imaging::Size& size)
         {
             TLRENDER_P();
@@ -853,6 +853,32 @@ namespace tl
         }
 
         void Render::end()
+        {}
+
+        void Render::beginRaster(const imaging::Size& viewportSize)
+        {
+            TLRENDER_P();
+
+            if (!p.shaders["text"]) return;
+
+            const auto viewMatrix = glm::ortho(
+                0.F,
+                static_cast<float>(viewportSize.w),
+                static_cast<float>(viewportSize.h),
+                0.F,
+                -1.F,
+                1.F);
+            const math::Matrix4x4f mvp(
+                viewMatrix[0][0], viewMatrix[0][1], viewMatrix[0][2], viewMatrix[0][3],
+                viewMatrix[1][0], viewMatrix[1][1], viewMatrix[1][2], viewMatrix[1][3],
+                viewMatrix[2][0], viewMatrix[2][1], viewMatrix[2][2], viewMatrix[2][3],
+                viewMatrix[3][0], viewMatrix[3][1], viewMatrix[3][2], viewMatrix[3][3]);
+
+            p.shaders["text"]->bind();
+            p.shaders["text"]->setUniform("transform.mvp", mvp);
+        }
+        
+        void Render::endRaster()
         {}
     }
 }

--- a/lib/tlGL/Render.h
+++ b/lib/tlGL/Render.h
@@ -30,6 +30,8 @@ namespace tl
             void setLUT(const timeline::LUTOptions&) override;
             void begin(const imaging::Size&) override;
             void end() override;
+            void beginRaster(const imaging::Size&) override;
+            void endRaster() override;
             void drawRect(
                 const math::BBox2i&,
                 const imaging::Color4f&) override;

--- a/lib/tlTimeline/IRender.h
+++ b/lib/tlTimeline/IRender.h
@@ -46,6 +46,12 @@ namespace tl
             //! Finish a render.
             virtual void end() = 0;
 
+            //! Start a text rendering in raster coordinates
+            virtual void beginRaster(const imaging::Size& viewport) = 0;
+            
+            //! Finish a text rendering in raster coordinates.
+            virtual void endRaster() = 0;
+            
             //! Draw a rectangle.
             virtual void drawRect(
                 const math::BBox2i&,


### PR DESCRIPTION
Here it is again the proposed API to render text in raster coordinates.  The code is identical to that of Render::begin(), Render::end() but the canvas is not cleared and the shader is not created (it is assumed it was created before hand).

The Render::endRaster() function is a no-op.  Only the Render::beginRaster(imaging::Size& viewportSize) changes the text shader matrix.

If the beginRaster() function is called before the Render::begin(), it will also not change the shader matrix.