### PR TITLE
Added matrix to drawMesh().

### DIFF
--- a/lib/tlGL/Render.h
+++ b/lib/tlGL/Render.h
@@ -36,7 +36,8 @@ namespace tl
                 const imaging::Color4f&) override;
             void drawMesh(
                 const geom::TriangleMesh2&,
-                const imaging::Color4f&) override;
+                const imaging::Color4f&,
+                const math::Matrix4x4f&) override;
             void drawText(
                 const std::vector<std::shared_ptr<imaging::Glyph> >& glyphs,
                 const math::Vector2i& position,

--- a/lib/tlGL/RenderPrims.cpp
+++ b/lib/tlGL/RenderPrims.cpp
@@ -12,7 +12,6 @@ namespace tl
 {
     namespace gl
     {
-        
         void Render::drawRect(
             const math::BBox2i& bbox,
             const imaging::Color4f& color)

--- a/lib/tlGL/RenderPrims.cpp
+++ b/lib/tlGL/RenderPrims.cpp
@@ -12,6 +12,7 @@ namespace tl
 {
     namespace gl
     {
+        
         void Render::drawRect(
             const math::BBox2i& bbox,
             const imaging::Color4f& color)
@@ -36,7 +37,8 @@ namespace tl
 
         void Render::drawMesh(
             const geom::TriangleMesh2& mesh,
-            const imaging::Color4f& color)
+            const imaging::Color4f& color,
+            const math::Matrix4x4f& mvp)
         {
             TLRENDER_P();
 
@@ -45,6 +47,7 @@ namespace tl
             {
                 p.shaders["mesh"]->bind();
                 p.shaders["mesh"]->setUniform("color", color);
+                p.shaders["mesh"]->setUniform("transform.mvp", mvp );
 
                 glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 

--- a/lib/tlTimeline/IRender.h
+++ b/lib/tlTimeline/IRender.h
@@ -47,7 +47,7 @@ namespace tl
 
             //! Finish a render.
             virtual void end() = 0;
-
+            
             //! Draw a rectangle.
             virtual void drawRect(
                 const math::BBox2i&,
@@ -56,7 +56,8 @@ namespace tl
             //! Draw a triangle mesh.
             virtual void drawMesh(
                 const geom::TriangleMesh2&,
-                const imaging::Color4f&) = 0;
+                const imaging::Color4f&,
+                const math::Matrix4x4f&) = 0;
 
             //! Draw text.
             virtual void drawText(


### PR DESCRIPTION
This is needed to support mvp projection for scaling and translation (zoom and panning) of the primitive together with the main viewport drawing of the image.  Render::begin() just sets a raster projection without taking into account zooming and panning.