### PR TITLE
Added drawRectOutline function.

### DIFF
--- a/lib/tlGL/Render.h
+++ b/lib/tlGL/Render.h
@@ -31,6 +31,9 @@ namespace tl
             void begin(const imaging::Size&,
                 const timeline::RenderOptions& = timeline::RenderOptions()) override;
             void end() override;
+            void drawRectOutline(
+                const math::BBox2i& bbox,
+                const imaging::Color4f& color) override;
             void drawRect(
                 const math::BBox2i&,
                 const imaging::Color4f&) override;

--- a/lib/tlGL/RenderPrims.cpp
+++ b/lib/tlGL/RenderPrims.cpp
@@ -12,6 +12,28 @@ namespace tl
 {
     namespace gl
     {
+        void Render::drawRectOutline(
+            const math::BBox2i& bbox,
+            const imaging::Color4f& color)
+        {
+            TLRENDER_P();
+
+            p.shaders["mesh"]->bind();
+            p.shaders["mesh"]->setUniform("color", color);
+
+            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+            if (p.vbos["rect"])
+            {
+                p.vbos["rect"]->copy(convert(geom::bbox(bbox), p.vbos["rect"]->getType()));
+            }
+            if (p.vaos["rect"])
+            {
+                p.vaos["rect"]->bind();
+                p.vaos["rect"]->draw(GL_LINE_LOOP, 0, p.vbos["rect"]->getSize());
+            }
+        }
+
         void Render::drawRect(
             const math::BBox2i& bbox,
             const imaging::Color4f& color)

--- a/lib/tlTimeline/IRender.h
+++ b/lib/tlTimeline/IRender.h
@@ -48,6 +48,11 @@ namespace tl
             //! Finish a render.
             virtual void end() = 0;
 
+            //! Draw a rectangle outline of a single pixel.
+            virtual void drawRectOutline(
+                const math::BBox2i& bbox,
+                const imaging::Color4f& color) = 0;
+
             //! Draw a rectangle.
             virtual void drawRect(
                 const math::BBox2i&,


### PR DESCRIPTION
This function draws one pixel rectangles perfectly.  It works much better for that than drawing a mesh as that outline can disappear when zoomed out on the display.