### PR TITLE
Fixed video duration when avVideoStream->nb_frames > 0.

### DIFF
--- a/lib/tlIO/FFmpegReadVideo.cpp
+++ b/lib/tlIO/FFmpegReadVideo.cpp
@@ -313,7 +313,11 @@ namespace tl
                 }
 
                 std::size_t sequenceSize = 0;
-                if (avVideoStream->duration != AV_NOPTS_VALUE)
+                if (avVideoStream->nb_frames > 0)
+                {
+                    sequenceSize = avVideoStream->nb_frames;
+                }
+                else if (avVideoStream->duration != AV_NOPTS_VALUE)
                 {
                     sequenceSize = av_rescale_q(
                         avVideoStream->duration,


### PR DESCRIPTION
When avVideoStream->nb_frames > 0, it overrides the stream duration.   See for example this movie:

https://mega.nz/file/3HgDUApI#eIzVWfblyQxeG8eVTxR5Yy_BE5USHskGbRSXKCgRW7Y

The streams are 2000 or so frames long, but the movie is shortened to 1428 frames (the value of avVideoStream->nb_frames).



