### PR TITLE
Fixes to FFmpegReadVideo

### DIFF
--- a/lib/tlIO/FFmpegReadPrivate.h
+++ b/lib/tlIO/FFmpegReadPrivate.h
@@ -86,7 +86,7 @@ namespace tl
             AVIOBufferData _avIOBufferData;
             uint8_t* _avIOContextBuffer = nullptr;
             AVIOContext* _avIOContext = nullptr;
-            AVRational    _avSpeed = { 24, 1 };
+            AVRational _avSpeed = { 24, 1 };
             int _avStream = -1;
             std::map<int, AVCodecParameters*> _avCodecParameters;
             std::map<int, AVCodecContext*> _avCodecContext;

--- a/lib/tlIO/FFmpegReadPrivate.h
+++ b/lib/tlIO/FFmpegReadPrivate.h
@@ -86,6 +86,7 @@ namespace tl
             AVIOBufferData _avIOBufferData;
             uint8_t* _avIOContextBuffer = nullptr;
             AVIOContext* _avIOContext = nullptr;
+            AVRational    _avSpeed = { 24, 1 };
             int _avStream = -1;
             std::map<int, AVCodecParameters*> _avCodecParameters;
             std::map<int, AVCodecContext*> _avCodecContext;

--- a/lib/tlIO/FFmpegReadVideo.cpp
+++ b/lib/tlIO/FFmpegReadVideo.cpp
@@ -311,14 +311,14 @@ namespace tl
                     break;
                 default: break;
                 }
-                
-                const double tbr = av_q2d(avVideoStream->r_frame_rate);
-                double speed = tbr;
 
+                _avSpeed = avVideoStream->r_frame_rate;
                 // Use avg_frame_rate if set
-                if ( avVideoStream->avg_frame_rate.num != 0 &&
-                     avVideoStream->avg_frame_rate.den != 0 )
-                    speed = av_q2d(avVideoStream->avg_frame_rate);
+                if (avVideoStream->avg_frame_rate.num != 0 &&
+                    avVideoStream->avg_frame_rate.den != 0)
+                    _avSpeed = avVideoStream->avg_frame_rate;
+                
+                const double speed = av_q2d(_avSpeed);
 
                 std::size_t sequenceSize = 0;
                 if (avVideoStream->nb_frames > 0)
@@ -549,16 +549,12 @@ namespace tl
             {
                 avcodec_flush_buffers(_avCodecContext[_avStream]);
 
-                AVRational speed = _avFormatContext->streams[_avStream]->avg_frame_rate;
-                if (speed.num == 0.0 || speed.den == 0.0)
-                    speed = _avFormatContext->streams[_avStream]->r_frame_rate;
-                
                 if (av_seek_frame(
                     _avFormatContext,
                     _avStream,
                     av_rescale_q(
                         time.value() - _timeRange.start_time().value(),
-                        swap(speed),
+                        swap(_avSpeed),
                         _avFormatContext->streams[_avStream]->time_base),
                     AVSEEK_FLAG_BACKWARD) < 0)
                 {


### PR DESCRIPTION
* color_primaries mixup
* speed (fps) frame rate used incorrectly
* seeking set incorrectly for some movies
* duration when nb_frames is set