### PR TITLE
Webm (libvpx) changes

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -45,6 +45,9 @@ jobs:
 
     - name: Install PulseAudio dev
       run: sudo apt-get install libpulse-dev
+      
+    - name: Install libvpx
+      run: sudo apt-get install libvpx-dev
 
     - name: Install Python dev
       if: env.TLRENDER_PYTHON == 'ON'
@@ -202,6 +205,9 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Install libvpx
+      run: brew install libvpx
+      
     # \bug DYLD_LIBRARY_PATH is not being set here?
     - name: Setup environment
       run: >

--- a/etc/SuperBuild/cmake/Modules/BuildFFmpeg.cmake
+++ b/etc/SuperBuild/cmake/Modules/BuildFFmpeg.cmake
@@ -36,6 +36,7 @@ else()
         --disable-audiotoolbox
         --disable-vaapi
         --disable-sdl2
+        --enable-libvpx
         --enable-pic
         ${FFmpeg_CFLAGS}
         ${FFmpeg_CXXFLAGS}

--- a/lib/tlIO/FFmpeg.cpp
+++ b/lib/tlIO/FFmpeg.cpp
@@ -125,6 +125,7 @@ namespace tl
                     { ".y4m", io::FileType::Movie },
                     { ".mkv", io::FileType::Movie },
                     { ".mxf", io::FileType::Movie },
+                    { ".webm", io::FileType::Movie },
                     { ".wmv", io::FileType::Movie },
                     { ".wav", io::FileType::Audio },
                     { ".mp3", io::FileType::Audio },

--- a/lib/tlIO/FFmpegReadVideo.cpp
+++ b/lib/tlIO/FFmpegReadVideo.cpp
@@ -306,26 +306,14 @@ namespace tl
                 }
                 switch (_avCodecParameters[_avStream]->color_space)
                 {
-                case AVCOL_SPC_BT2020_NCL:
+                case AVCOL_PRI_BT2020:
                     _info.yuvCoefficients = imaging::YUVCoefficients::BT2020;
                     break;
                 default: break;
                 }
-                
-                const double tbr = av_q2d(avVideoStream->r_frame_rate);
-                double speed = tbr;
-
-                // Use avg_frame_rate if set
-                if ( avVideoStream->avg_frame_rate.num != 0 &&
-                     avVideoStream->avg_frame_rate.den != 0 )
-                    speed = av_q2d(avVideoStream->avg_frame_rate);
 
                 std::size_t sequenceSize = 0;
-                if (avVideoStream->nb_frames > 0)
-                {
-                    sequenceSize = avVideoStream->nb_frames;
-                }
-                else if (avVideoStream->duration != AV_NOPTS_VALUE)
+                if (avVideoStream->duration != AV_NOPTS_VALUE)
                 {
                     sequenceSize = av_rescale_q(
                         avVideoStream->duration,
@@ -339,7 +327,9 @@ namespace tl
                         av_get_time_base_q(),
                         swap(avVideoStream->r_frame_rate));
                 }
-        
+
+                const double speed = avVideoStream->r_frame_rate.num / double(avVideoStream->r_frame_rate.den);
+
                 imaging::Tags tags;
                 AVDictionaryEntry* tag = nullptr;
                 while ((tag = av_dict_get(_avFormatContext->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
@@ -549,16 +539,12 @@ namespace tl
             {
                 avcodec_flush_buffers(_avCodecContext[_avStream]);
 
-                AVRational speed = _avFormatContext->streams[_avStream]->avg_frame_rate;
-                if (speed.num == 0.0 || speed.den == 0.0)
-                    speed = _avFormatContext->streams[_avStream]->r_frame_rate;
-                
                 if (av_seek_frame(
                     _avFormatContext,
                     _avStream,
                     av_rescale_q(
                         time.value() - _timeRange.start_time().value(),
-                        swap(speed),
+                        swap(_avFormatContext->streams[_avStream]->r_frame_rate),
                         _avFormatContext->streams[_avStream]->time_base),
                     AVSEEK_FLAG_BACKWARD) < 0)
                 {


### PR DESCRIPTION
This change adds libvpx support to CI, FFmpeg build as well as tlRender's extension support.
This is a simple PR to link the libvpx library dynamically. But in fact, it should be built statically.