### PR TITLE
Fixed audio race condition turning running into true in video thread.

### DIFF
--- a/lib/tlIO/FFmpegRead.cpp
+++ b/lib/tlIO/FFmpegRead.cpp
@@ -223,10 +223,12 @@ namespace tl
             p.audioThread.running = false;
             if (p.videoThread.thread.joinable())
             {
+                p.videoThread.running = false;
                 p.videoThread.thread.join();
             }
             if (p.audioThread.thread.joinable())
             {
+                p.audioThread.running = false;
                 p.audioThread.thread.join();
             }
         }

--- a/lib/tlIO/FFmpegRead.cpp
+++ b/lib/tlIO/FFmpegRead.cpp
@@ -119,6 +119,7 @@ namespace tl
             }
 
             p.videoThread.running = true;
+            p.audioThread.running = true;
             p.videoThread.thread = std::thread(
                 [this, path]
                 {
@@ -140,7 +141,6 @@ namespace tl
 
                         p.infoPromise.set_value(p.info);
 
-                        p.audioThread.running = true;
                         p.audioThread.thread = std::thread(
                             [this, path]
                             {
@@ -223,12 +223,10 @@ namespace tl
             p.audioThread.running = false;
             if (p.videoThread.thread.joinable())
             {
-                p.videoThread.running = false;
                 p.videoThread.thread.join();
             }
             if (p.audioThread.thread.joinable())
             {
-                p.audioThread.running = false;
                 p.audioThread.thread.join();
             }
         }


### PR DESCRIPTION
This would create hang ups when loading two or more clips, when comparing clips in wipe or when switching clips sometimes.

The reason was a race condition that would happen when FFmpegRead was created and quickly deleted.

The video thread sets p.audioThread.running to true before the audio thread starts.

While the destructor of FFmpegRead would set it to false before joining the video and audio thread.

Sometimes, this would lead to p.audioThread.running = true in the destructor (as the video thread would set just before) and then joining the audio thread would loop indefinitively.

I added two running = false statements before joining both threads just in case (the video one is probably unneeded for now).