### PR TITLE
Added HUD with skipped frames.

### DIFF
--- a/lib/tlQtWidget/TimelineViewport.h
+++ b/lib/tlQtWidget/TimelineViewport.h
@@ -99,8 +99,9 @@ namespace tl
             void mouseReleaseEvent(QMouseEvent*) override;
             void mouseMoveEvent(QMouseEvent*) override;
             void wheelEvent(QWheelEvent*) override;
-
         private:
+            void _drawHUD();
+
             imaging::Size _viewportSize() const;
             imaging::Size _renderSize() const;
             math::Vector2i _viewportCenter() const;


### PR DESCRIPTION
I added a feature to tlplay (libQtWidget/TimelineViewport.cpp) that I find handy.  It measures the number of skipped frames between each call to paintGL.

I use this to watch the behavior of SolLevante.