### PR TITLE
Fixed threading issue with RtAudio on Windows and Linux.

### DIFF
--- a/lib/tlTimeline/Player.cpp
+++ b/lib/tlTimeline/Player.cpp
@@ -234,7 +234,7 @@ namespace tl
                             audioOffset,
                             cacheDirection,
                             cacheOptions);
-                        
+
                         // Update the current video data.
                         const auto& timeRange = p.timeline->getTimeRange();
                         if (!p.ioInfo.video.empty())
@@ -927,7 +927,6 @@ namespace tl
                 currentAudioData = p.mutex.currentAudioData;
                 cacheInfo = p.mutex.cacheInfo;
             }
-            
             p.currentVideoData->setIfChanged(currentVideoData);
             p.currentAudioData->setIfChanged(currentAudioData);
             p.cacheInfo->setIfChanged(cacheInfo);

--- a/lib/tlTimeline/Player.cpp
+++ b/lib/tlTimeline/Player.cpp
@@ -124,7 +124,21 @@ namespace tl
             p.mutex.cacheInfo = p.cacheInfo->get();
             p.audioMutex.speed = p.speed->get();
 #if defined(TLRENDER_AUDIO)
-            p.thread.rtAudio.reset(new RtAudio);
+            try
+            {
+                p.thread.rtAudio.reset(new RtAudio);
+            }
+            catch (const std::exception& e)
+            {
+                std::stringstream ss;
+                ss << "Cannot open create RtAudio instance: " << e.what();
+                context->log("tl::timeline::Player", ss.str(), log::Type::Error);
+            }
+            if (!p.thread.rtAudio)
+            {
+                p.thread.running = false;
+                return;
+            }
 #endif
             p.thread.running = true;
             p.thread.thread = std::thread(

--- a/lib/tlTimeline/Player.cpp
+++ b/lib/tlTimeline/Player.cpp
@@ -130,9 +130,12 @@ namespace tl
             }
             catch (const std::exception& e)
             {
-                std::stringstream ss;
-                ss << "Cannot open create RtAudio instance: " << e.what();
-                context->log("tl::timeline::Player", ss.str(), log::Type::Error);
+                if (auto context = getContext().lock())
+                {
+                    std::stringstream ss;
+                    ss << "Cannot open create RtAudio instance: " << e.what();
+                    context->log("tl::timeline::Player", ss.str(), log::Type::Error);
+                }
             }
             if (!p.thread.rtAudio)
             {

--- a/lib/tlTimeline/Player.cpp
+++ b/lib/tlTimeline/Player.cpp
@@ -123,6 +123,9 @@ namespace tl
             p.mutex.cacheOptions = p.cacheOptions->get();
             p.mutex.cacheInfo = p.cacheInfo->get();
             p.audioMutex.speed = p.speed->get();
+#if defined(TLRENDER_AUDIO)
+            p.thread.rtAudio.reset(new RtAudio);
+#endif
             p.thread.running = true;
             p.thread.thread = std::thread(
                 [this]
@@ -143,7 +146,6 @@ namespace tl
                             {
                                 try
                                 {
-                                    p.thread.rtAudio.reset(new RtAudio);
                                     RtAudio::StreamParameters rtParameters;
                                     auto audioSystem = context->getSystem<audio::System>();
                                     rtParameters.deviceId = audioSystem->getDefaultOutputDevice();
@@ -165,7 +167,7 @@ namespace tl
                                 {
                                     std::stringstream ss;
                                     ss << "Cannot open audio stream: " << e.what();
-                                    context->log("tl::timline::Player", ss.str(), log::Type::Error);
+                                    context->log("tl::timeline::Player", ss.str(), log::Type::Error);
                                 }
                             }
                         }
@@ -232,7 +234,7 @@ namespace tl
                             audioOffset,
                             cacheDirection,
                             cacheOptions);
-
+                        
                         // Update the current video data.
                         const auto& timeRange = p.timeline->getTimeRange();
                         if (!p.ioInfo.video.empty())
@@ -925,6 +927,7 @@ namespace tl
                 currentAudioData = p.mutex.currentAudioData;
                 cacheInfo = p.mutex.cacheInfo;
             }
+            
             p.currentVideoData->setIfChanged(currentVideoData);
             p.currentAudioData->setIfChanged(currentAudioData);
             p.cacheInfo->setIfChanged(cacheInfo);


### PR DESCRIPTION
I found out that on Windows, another issue caused by RtAudio would happen which would prevent Drag and Drop in FLTK to work after loading 4 clips with audio. 
The issue with both seems to be that the RtAudio pointer is instantiated within the std::thread body and that creates issues with audio apis which are not multithreaded.  I moved the instantiation of RtAudio outside of the thread, and the issue seems to be fixed.