### PR TITLE
Cmdline parsing

### DIFF
--- a/lib/tlApp/CmdLine.h
+++ b/lib/tlApp/CmdLine.h
@@ -103,7 +103,8 @@ namespace tl
             ICmdLineArg(
                 const std::string& name,
                 const std::string& help,
-                bool optional);
+                bool optional,
+                bool unused = false);
 
         public:
             virtual ~ICmdLineArg() = 0;
@@ -119,11 +120,15 @@ namespace tl
 
             //! Get whether this argument is optional.
             bool isOptional() const;
+            
+            //! Get whether this argument is for unused arguments.
+            bool isUnused() const;
 
         protected:
             std::string _name;
             std::string _help;
             bool _optional = false;
+            bool _unused   = false;
         };
 
         //! Command line value argument.
@@ -135,7 +140,8 @@ namespace tl
                 T& value,
                 const std::string& name,
                 const std::string& help,
-                bool optional);
+                bool optional,
+                bool unused = false);
 
         public:
             //! Create a new command line argument.
@@ -143,7 +149,8 @@ namespace tl
                 T& value,
                 const std::string& name,
                 const std::string& help,
-                bool optional = false);
+                bool optional = false,
+                bool unused = false);
 
             void parse(std::vector<std::string>& args) override;
 

--- a/lib/tlApp/CmdLineInline.h
+++ b/lib/tlApp/CmdLineInline.h
@@ -6,7 +6,6 @@
 #include <tlCore/String.h>
 
 #include <algorithm>
-#include <iostream>
 
 namespace tl
 {

--- a/lib/tlApp/CmdLineInline.h
+++ b/lib/tlApp/CmdLineInline.h
@@ -6,6 +6,7 @@
 #include <tlCore/String.h>
 
 #include <algorithm>
+#include <iostream>
 
 namespace tl
 {
@@ -112,10 +113,12 @@ namespace tl
         inline ICmdLineArg::ICmdLineArg(
             const std::string& name,
             const std::string& help,
-            bool optional) :
+            bool optional,
+            bool unused) :
             _name(name),
             _help(help),
-            _optional(optional)
+            _optional(optional),
+            _unused(unused)
         {}
 
         inline ICmdLineArg::~ICmdLineArg()
@@ -136,13 +139,19 @@ namespace tl
             return _optional;
         }
 
+        inline bool ICmdLineArg::isUnused() const
+        {
+            return _unused;
+        }
+
         template<typename T>
         inline CmdLineValueArg<T>::CmdLineValueArg(
             T& value,
             const std::string& name,
             const std::string& help,
-            bool optional) :
-            ICmdLineArg(name, help, optional),
+            bool optional,
+            bool unused) :
+            ICmdLineArg(name, help, optional, unused),
             _value(value)
         {}
 
@@ -151,9 +160,10 @@ namespace tl
             T& value,
             const std::string& name,
             const std::string& help,
-            bool optional)
+            bool optional,
+            bool unused)
         {
-            return std::shared_ptr<CmdLineValueArg<T> >(new CmdLineValueArg<T>(value, name, help, optional));
+            return std::shared_ptr<CmdLineValueArg<T> >(new CmdLineValueArg<T>(value, name, help, optional, unused));
         }
 
         template<typename T>

--- a/lib/tlApp/IApp.h
+++ b/lib/tlApp/IApp.h
@@ -62,6 +62,9 @@ namespace tl
             //! Get the exit code.
             int getExit() const;
 
+            //! Get unused arguments
+            const std::vector<std::string> getUnusedArgs() const;
+            
         protected:
             void _log(const std::string&, log::Type = log::Type::Message);
 
@@ -69,6 +72,7 @@ namespace tl
             void _printNewline();
             void _printError(const std::string&);
 
+            std::vector<std::string> _unusedArgs;
             std::shared_ptr<system::Context> _context;
             Options _options;
             int _exit = 0;


### PR DESCRIPTION
Added command-line parsing with unused arguments.  The idea is that the arguments that are not parsed are left as unused arguments.  This can be used, for example, to parse multiple images on the command-line, like:

mrv2 -p Stop ~/Pictures/*

