### PR TITLE
Added support for YUVA formats in FFmpegRead.cpp

### DIFF
--- a/lib/tlIO/FFmpegReadVideo.cpp
+++ b/lib/tlIO/FFmpegReadVideo.cpp
@@ -253,13 +253,6 @@ namespace tl
                     _avOutputPixelFormat = AV_PIX_FMT_RGBA;
                     _info.pixelType = image::PixelType::RGBA_U8;
                     // }
-                    // else
-                    // {
-                    //     //! \todo Use the _info.layout.endian field instead of
-                    //     //! converting endianness.
-                    //     _avOutputPixelFormat = AV_PIX_FMT_YUV444P16LE;
-                    //     _info.pixelType = image::PixelType::YUV_444P_U16;
-                    // }
                     break;
                 case AV_PIX_FMT_YUVA444P10BE:
                 case AV_PIX_FMT_YUVA444P10LE:
@@ -270,15 +263,8 @@ namespace tl
                     //! \todo Support these formats natively.
                     // if (options.yuvToRGBConversion)
                     // {
-                        _avOutputPixelFormat = AV_PIX_FMT_RGBA64LE;
+                        _avOutputPixelFormat = AV_PIX_FMT_RGBA64;
                         _info.pixelType = image::PixelType::RGBA_U16;
-                    // }
-                    // else
-                    // {
-                    //     //! \todo Use the _info.layout.endian field instead of
-                    //     //! converting endianness.
-                    //     _avOutputPixelFormat = AV_PIX_FMT_YUV444P16LE;
-                    //     _info.pixelType = image::PixelType::YUV_444P_U16;
                     // }
                     break;
                 default:

--- a/lib/tlIO/FFmpegReadVideo.cpp
+++ b/lib/tlIO/FFmpegReadVideo.cpp
@@ -231,12 +231,6 @@ namespace tl
                 case AV_PIX_FMT_YUV444P12LE:
                 case AV_PIX_FMT_YUV444P16BE:
                 case AV_PIX_FMT_YUV444P16LE:
-                case AV_PIX_FMT_YUVA444P10BE:
-                case AV_PIX_FMT_YUVA444P10LE:
-                case AV_PIX_FMT_YUVA444P12BE:
-                case AV_PIX_FMT_YUVA444P12LE:
-                case AV_PIX_FMT_YUVA444P16BE:
-                case AV_PIX_FMT_YUVA444P16LE:
                     if (options.yuvToRGBConversion)
                     {
                         _avOutputPixelFormat = AV_PIX_FMT_RGB48;
@@ -249,6 +243,43 @@ namespace tl
                         _avOutputPixelFormat = AV_PIX_FMT_YUV444P16LE;
                         _info.pixelType = image::PixelType::YUV_444P_U16;
                     }
+                    break;
+                case AV_PIX_FMT_YUVA420P:
+                case AV_PIX_FMT_YUVA422P:
+                case AV_PIX_FMT_YUVA444P:
+                    //! \todo Support these formats natively.
+                    // if (options.yuvToRGBConversion)
+                    // {
+                    _avOutputPixelFormat = AV_PIX_FMT_RGBA;
+                    _info.pixelType = image::PixelType::RGBA_U8;
+                    // }
+                    // else
+                    // {
+                    //     //! \todo Use the _info.layout.endian field instead of
+                    //     //! converting endianness.
+                    //     _avOutputPixelFormat = AV_PIX_FMT_YUV444P16LE;
+                    //     _info.pixelType = image::PixelType::YUV_444P_U16;
+                    // }
+                    break;
+                case AV_PIX_FMT_YUVA444P10BE:
+                case AV_PIX_FMT_YUVA444P10LE:
+                case AV_PIX_FMT_YUVA444P12BE:
+                case AV_PIX_FMT_YUVA444P12LE:
+                case AV_PIX_FMT_YUVA444P16BE:
+                case AV_PIX_FMT_YUVA444P16LE:
+                    //! \todo Support these formats natively.
+                    // if (options.yuvToRGBConversion)
+                    // {
+                        _avOutputPixelFormat = AV_PIX_FMT_RGBA64LE;
+                        _info.pixelType = image::PixelType::RGBA_U16;
+                    // }
+                    // else
+                    // {
+                    //     //! \todo Use the _info.layout.endian field instead of
+                    //     //! converting endianness.
+                    //     _avOutputPixelFormat = AV_PIX_FMT_YUV444P16LE;
+                    //     _info.pixelType = image::PixelType::YUV_444P_U16;
+                    // }
                     break;
                 default:
                     if (options.yuvToRGBConversion)


### PR DESCRIPTION
Added support for YUVA formats by converting them to RGBA_U8 and RGBA_U16.

Don't know if you plan to support YUVA natively in the shaders, but in the meantime we can support YUVA by converting to RGBA.