### PR TITLE
Fixed sequence detection.

### DIFF
--- a/lib/tlCore/FileInfo.cpp
+++ b/lib/tlCore/FileInfo.cpp
@@ -35,7 +35,8 @@ namespace tl
         {
             if (!_path.getNumber().empty() &&
                 !value._path.getNumber().empty() &&
-                _path.getPadding() == value._path.getPadding())
+                (_path.getPadding() == value._path.getPadding() ||
+                 _path.getPadding() == value._path.getNumber().size()))
             {
                 math::IntRange sequence = _path.getSequence();
                 const math::IntRange& otherSequence = value._path.getSequence();

--- a/tests/tlCoreTest/FileInfoTest.cpp
+++ b/tests/tlCoreTest/FileInfoTest.cpp
@@ -102,6 +102,16 @@ namespace tl
                 f.sequence(FileInfo(Path("test.exr")));
                 TLRENDER_ASSERT(f.getPath().getSequence() == math::IntRange(3, 3));
             }
+            {
+                FileInfo f(Path("test0999.exr"));
+                f.sequence(FileInfo(Path("test1000.exr")));
+                TLRENDER_ASSERT(f.getPath().getSequence() == math::IntRange(999, 1000));
+            }
+            {
+                FileInfo f(Path("0001.exr"));
+                f.sequence(FileInfo(Path("7800.exr")));
+                TLRENDER_ASSERT(f.getPath().getSequence() == math::IntRange(1, 7800));
+            }
         }
 
         void FileInfoTest::_list()


### PR DESCRIPTION
When it reached the number of padded digits, it would fail. For example:

test.09.exr
test.10.exr
test.11.exr

would result in the sequence being 01-09 only.