### PR TITLE
Flip U16 formats too.

### DIFF
--- a/lib/tlIO/FFmpegWrite.cpp
+++ b/lib/tlIO/FFmpegWrite.cpp
@@ -315,8 +315,8 @@ namespace tl
             case image::PixelType::L_U8:
             case image::PixelType::L_U16:
             case image::PixelType::RGB_U8:
-            case image::PixelType::RGBA_U8:
             case image::PixelType::RGB_U16:
+            case image::PixelType::RGBA_U8:
             case image::PixelType::RGBA_U16:
             {
                 const size_t channelCount = image::getChannelCount(info.pixelType);

--- a/lib/tlIO/FFmpegWrite.cpp
+++ b/lib/tlIO/FFmpegWrite.cpp
@@ -313,8 +313,11 @@ namespace tl
             switch (info.pixelType)
             {
             case image::PixelType::L_U8:
+            case image::PixelType::L_U16:
             case image::PixelType::RGB_U8:
             case image::PixelType::RGBA_U8:
+            case image::PixelType::RGB_U16:
+            case image::PixelType::RGBA_U16:
             {
                 const size_t channelCount = image::getChannelCount(info.pixelType);
                 for (size_t i = 0; i < channelCount; i++)


### PR DESCRIPTION
Flipping on U16 formats is currently not happening leading to movies saved vertically incorrect.