### PR TITLE
Added all audio changes for Darby to review.

### DIFF
--- a/lib/tlCore/Audio.h
+++ b/lib/tlCore/Audio.h
@@ -178,12 +178,21 @@ namespace tl
         //! \name Utility
         ///@{
 
+        //! Reverse audio sources in place.
+        void reverse(
+            uint8_t** inOut,
+            size_t          inCount,
+            size_t          sampleCount,
+            uint8_t         channelCount,
+            DataType        dataType);
+        
         //! Mix audio sources.
         void mix(
             const uint8_t** in,
             size_t          inCount,
             uint8_t*        out,
             float           volume,
+            const std::vector<float>& volumeScale,
             size_t          sampleCount,
             size_t          channelCount,
             DataType        dataType);

--- a/lib/tlTimeline/Audio.h
+++ b/lib/tlTimeline/Audio.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <opentimelineio/transition.h>
+
 #include <tlIO/IO.h>
 
 namespace tl
@@ -15,6 +17,10 @@ namespace tl
         {
             std::shared_ptr<audio::Audio> audio;
 
+            otime::TimeRange  clipTimeRange;
+            otio::Transition* inTransition = nullptr;
+            otio::Transition* outTransition = nullptr;
+            
             bool operator == (const AudioLayer&) const;
             bool operator != (const AudioLayer&) const;
         };

--- a/lib/tlTimeline/Player.cpp
+++ b/lib/tlTimeline/Player.cpp
@@ -123,6 +123,7 @@ namespace tl
             p.mutex.cacheOptions = p.cacheOptions->get();
             p.mutex.cacheInfo = p.cacheInfo->get();
             p.audioMutex.speed = p.speed->get();
+            p.audioMutex.defaultSpeed = p.speed->get();
 #if defined(TLRENDER_AUDIO)
             try
             {

--- a/lib/tlTimeline/PlayerPrivate.cpp
+++ b/lib/tlTimeline/PlayerPrivate.cpp
@@ -512,6 +512,7 @@ namespace tl
                     {
                         p->audioThread.resample->flush();
                     }
+                    p->audioThread.silence.reset();
                     p->audioThread.buffer.clear();
                     p->audioThread.rtAudioCurrentFrame = 0;
                     p->audioThread.backwardsSize =
@@ -681,8 +682,7 @@ namespace tl
                         if (audioDataP.empty())
                         {
                             volumeScale.push_back(0.F);
-                            audioDataP.push_back(
-                                p->audioThread.silence->getData() + dataOffset);
+                            audioDataP.push_back(p->audioThread.silence->getData());
                         }
 
                         size_t size = std::min(

--- a/lib/tlTimeline/PlayerPrivate.h
+++ b/lib/tlTimeline/PlayerPrivate.h
@@ -103,6 +103,7 @@ namespace tl
             struct AudioMutex
             {
                 double speed = 0.0;
+                double defaultSpeed = 0.0;
                 float volume = 1.F;
                 bool mute = false;
                 std::chrono::steady_clock::time_point muteTimeout;
@@ -134,6 +135,7 @@ namespace tl
                 std::list<std::shared_ptr<audio::Audio> > buffer;
                 std::shared_ptr<audio::Audio> silence;
                 size_t rtAudioCurrentFrame = 0;
+                size_t backwardsSize = std::numeric_limits<size_t>::max();
             };
             AudioThread audioThread;
         };

--- a/lib/tlTimeline/TimelinePrivate.h
+++ b/lib/tlTimeline/TimelinePrivate.h
@@ -84,7 +84,10 @@ namespace tl
 
                 double seconds = -1.0;
                 otime::TimeRange timeRange;
+                otime::TimeRange clipTimeRange;
                 std::future<io::AudioData> audio;
+                otio::Transition* inTransition = nullptr;
+                otio::Transition* outTransition = nullptr;
             };
             struct AudioRequest
             {

--- a/tests/tlCoreTest/AudioTest.cpp
+++ b/tests/tlCoreTest/AudioTest.cpp
@@ -146,11 +146,15 @@ namespace tl
                     std::numeric_limits<T>::max() + std::numeric_limits<T>::min(),
                     std::numeric_limits<T>::max() + std::numeric_limits<T>::min()
                 };
+                std::vector<float> volumeScale;
+                volumeScale.push_back(1.F);
+                volumeScale.push_back(1.F);
                 std::vector<T> result(in0.size(), 0);
                 mix(in,
                     2,
                     reinterpret_cast<uint8_t*>(result.data()),
                     1.F,
+                    volumeScale,
                     in0.size(),
                     1,
                     DT);
@@ -192,11 +196,15 @@ namespace tl
                     0,
                     0
                 };
+                std::vector<float> volumeScale;
+                volumeScale.push_back(1.F);
+                volumeScale.push_back(1.F);
                 std::vector<T> result(in0.size(), 0);
                 mix(in,
                     2,
                     reinterpret_cast<uint8_t*>(result.data()),
                     1.F,
+                    volumeScale,
                     in0.size(),
                     1,
                     DT);


### PR DESCRIPTION
This PR contains all audio changes for you to review and before you refactor the audio code.  Except there's a big bug, I won't do any changes to it.  I thought you can use it as a reference and to incorporate the features if you refactor the audio code.

It contains:

- Reverse audio playback.
- Resample of audio when FPS changes.
- OpenTimelineIO audio transitions on multiple layers.

It was tested with mrv2 and with tlplay-gl.sh.

It makes all previous audio PRs obsolete (which I will be closing).