### PR TITLE
Fix various typos

### DIFF
--- a/lib/tlCore/AudioSystem.cpp
+++ b/lib/tlCore/AudioSystem.cpp
@@ -177,7 +177,7 @@ namespace tl
             catch (const std::exception& e)
             {
                 std::stringstream ss;
-                ss << "Cannot initalize audio system: " << e.what();
+                ss << "Cannot initialize audio system: " << e.what();
                 _log(ss.str(), log::Type::Error);
             }
 #endif // TLRENDER_AUDIO

--- a/lib/tlCore/Math.h
+++ b/lib/tlCore/Math.h
@@ -15,10 +15,10 @@ namespace tl
         //! Approximate value of PI times two.
         constexpr float pi2 = pi * 2.F;
 
-        //! Convert degress to radians.
+        //! Convert degrees to radians.
         constexpr float deg2rad(float);
 
-        //! Convert radians to degress.
+        //! Convert radians to degrees.
         constexpr float rad2deg(float);
 
         //! Clamp a value.

--- a/lib/tlCore/Memory.h
+++ b/lib/tlCore/Memory.h
@@ -33,7 +33,7 @@ namespace tl
         //! Endian type.
         enum class Endian
         {
-            MSB, //!< Most siginificant byte first
+            MSB, //!< Most significant byte first
             LSB, //!< Least significant byte first
 
             Count,

--- a/lib/tlDevice/BMD/Linux/platform.h
+++ b/lib/tlDevice/BMD/Linux/platform.h
@@ -39,7 +39,7 @@ HRESULT GetDeckLinkIterator(IDeckLinkIterator **deckLinkIterator);
 #define dlbool_t	bool
 #define dlstring_t	const char*
 
-// DeckLink String conversion fucntions
+// DeckLink String conversion functions
 const std::function<void(dlstring_t)> DeleteString = [](dlstring_t dl_str) { free((void*)dl_str); };
 const std::function<std::string(dlstring_t)> DlToStdString = [](dlstring_t dl_str) -> std::string { return dl_str; };
 const std::function<dlstring_t(std::string)> StdToDlString = [](std::string std_str) -> dlstring_t { 

--- a/lib/tlDevice/BMD/Linux/platform.h
+++ b/lib/tlDevice/BMD/Linux/platform.h
@@ -39,7 +39,7 @@ HRESULT GetDeckLinkIterator(IDeckLinkIterator **deckLinkIterator);
 #define dlbool_t	bool
 #define dlstring_t	const char*
 
-// DeckLink String conversion functions
+// DeckLink String conversion fucntions
 const std::function<void(dlstring_t)> DeleteString = [](dlstring_t dl_str) { free((void*)dl_str); };
 const std::function<std::string(dlstring_t)> DlToStdString = [](dlstring_t dl_str) -> std::string { return dl_str; };
 const std::function<dlstring_t(std::string)> StdToDlString = [](std::string std_str) -> dlstring_t { 

--- a/lib/tlIO/PNG.h
+++ b/lib/tlIO/PNG.h
@@ -24,7 +24,7 @@ namespace tl
             //! PNG error function.
             void errorFunc(png_structp in, png_const_charp msg);
 
-            //! PNG warning functin.
+            //! PNG warning function.
             void warningFunc(png_structp in, png_const_charp msg);
         }
 

--- a/lib/tlPlay/App.h
+++ b/lib/tlPlay/App.h
@@ -49,10 +49,10 @@ namespace tl
             std::string settingsFileName;
         };
 
-        //! Get the applicaiton command line arguments.
+        //! Get the application command line arguments.
         std::vector<std::shared_ptr<app::ICmdLineArg> > getCmdLineArgs(Options&);
 
-        //! Get the applicaiton command line options.
+        //! Get the application command line options.
         std::vector<std::shared_ptr<app::ICmdLineOption> > getCmdLineOptions(
             Options&,
             const std::string& logFileName,

--- a/lib/tlPlayQtApp/App.h
+++ b/lib/tlPlayQtApp/App.h
@@ -118,7 +118,7 @@ namespace tl
             //! Open a file with separate audio dialog.
             void openSeparateAudioDialog();
 
-            //! Set whether the scondary window is active.
+            //! Set whether the secondary window is active.
             void setSecondaryWindow(bool);
 
         Q_SIGNALS:

--- a/lib/tlQt/TimelinePlayer.h
+++ b/lib/tlQt/TimelinePlayer.h
@@ -125,7 +125,7 @@ namespace tl
             //! Get the time range.
             const otime::TimeRange& timeRange() const;
 
-            //! Get the I/O information. This information is retreived from
+            //! Get the I/O information. This information is retrieved from
             //! the first clip in the timeline.
             const io::Info& ioInfo() const;
 
@@ -281,7 +281,7 @@ namespace tl
             //! \name I/O
             ///@{
 
-            //! Set the I/O optoins.
+            //! Set the I/O options.
             void setIOOptions(const tl::io::Options&);
 
             ///@}

--- a/lib/tlTimeline/Player.h
+++ b/lib/tlTimeline/Player.h
@@ -123,7 +123,7 @@ namespace tl
             //! Get the time range.
             const otime::TimeRange& getTimeRange() const;
 
-            //! Get the I/O information. This information is retreived from
+            //! Get the I/O information. This information is retrieved from
             //! the first clip in the timeline.
             const io::Info& getIOInfo() const;
 

--- a/lib/tlTimeline/Timeline.h
+++ b/lib/tlTimeline/Timeline.h
@@ -151,7 +151,7 @@ namespace tl
             //! Get the time range.
             const otime::TimeRange& getTimeRange() const;
 
-            //! Get the I/O information. This information is retreived from
+            //! Get the I/O information. This information is retrieved from
             //! the first clip in the timeline.
             const io::Info& getIOInfo() const;
 

--- a/lib/tlTimelineUI/TimelineItem.h
+++ b/lib/tlTimelineUI/TimelineItem.h
@@ -26,7 +26,7 @@ namespace tl
         //! \todo Add support for dragging clips to different tracks.
         //! \todo Add support for adjusting clip handles.
         //! \todo Add support for undo/redo.
-        //! \todo Add an option for viewing/playing indiviual clips ("solo" mode).
+        //! \todo Add an option for viewing/playing individual clips ("solo" mode).
         class TimelineItem : public IItem
         {
         protected:

--- a/lib/tlUI/Event.h
+++ b/lib/tlUI/Event.h
@@ -112,7 +112,7 @@ namespace tl
         const KeyModifier commandKeyModifier = KeyModifier::Control;
 #endif // __APPLE__
 
-        //! Get a keyboard modifer label.
+        //! Get a keyboard modifier label.
         std::string getKeyModifierLabel(int);
 
         //! Mouse click event.

--- a/lib/tlUI/IWidget.h
+++ b/lib/tlUI/IWidget.h
@@ -166,7 +166,7 @@ namespace tl
             //! Does this widget accept key focus?
             bool acceptsKeyFocus() const;
 
-            //! Set whether the widget acceps key focus.
+            //! Set whether the widget accepts key focus.
             void setAcceptsKeyFocus(bool);
 
             //! Does this widget have key focus?


### PR DESCRIPTION
Found via `codespell -q 3 -S "./deps,./LICENSE.txt,./etc/Legal/LICENSE*" -L filetest,inout,delimeter,delimeters`