### PR TITLE
Wayland fix for current NVidia's libnvidia-egl-wayland1 driver.

### DIFF
--- a/lib/tlGL/GLFWSystem.cpp
+++ b/lib/tlGL/GLFWSystem.cpp
@@ -13,6 +13,7 @@
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
+#include <cstring>
 #include <iostream>
 
 namespace tl
@@ -25,6 +26,21 @@ namespace tl
             {
                 std::cerr << "GLFW ERROR: " << description << std::endl;
             }
+        }
+
+        bool isWayland()
+        {
+            bool out = false;
+#ifdef __linux__
+            char* platform = getenv("FLTK_BACKEND");
+            if (!platform)
+                platform = getenv("XDG_SESSION_TYPE");
+            if (platform && strcmp(platform, "wayland") == 0)
+            {
+                out = true;
+            }
+#endif  // __linux__
+            return out;
         }
         
         struct GLFWSystem::Private
@@ -44,6 +60,15 @@ namespace tl
             int glfwRevision = 0;
             glfwGetVersion(&glfwMajor, &glfwMinor, &glfwRevision);
             _log(string::Format("GLFW version: {0}.{1}.{2}").arg(glfwMajor).arg(glfwMinor).arg(glfwRevision));
+                      
+            int platform_hint = GLFW_PLATFORM_X11;
+            if (isWayland())
+            {
+                platform_hint = GLFW_PLATFORM_WAYLAND;
+            }
+               
+            if (glfwPlatformSupported(platform_hint) == GLFW_TRUE)
+                glfwInitHint(GLFW_PLATFORM, platform_hint);
             if (!glfwInit())
             {
                 //! \todo Only log the error for now so that non-OpenGL
@@ -51,7 +76,7 @@ namespace tl
                 //throw std::runtime_error("Cannot initialize GLFW");
                 auto logSystem = context->getSystem<log::System>();
                 logSystem->print("tl::gl::GLFWSystem", "Cannot initialize GLFW", log::Type::Error);
-            }
+            }            
             p.glfwInit = true;
         }
         

--- a/lib/tlGL/GLFWSystem.h
+++ b/lib/tlGL/GLFWSystem.h
@@ -10,6 +10,8 @@ namespace tl
 {
     namespace gl
     {
+        bool isWayland();
+        
         //! GLFW system.
         class GLFWSystem : public system::ISystem
         {

--- a/lib/tlGL/GLFWWindow.cpp
+++ b/lib/tlGL/GLFWWindow.cpp
@@ -5,6 +5,7 @@
 #include <tlGL/GLFWWindow.h>
 
 #include <tlGL/GL.h>
+#include <tlGL/GLFWSystem.h>
 #include <tlGL/Init.h>
 
 #include <tlCore/Context.h>
@@ -53,6 +54,23 @@ namespace tl
 #endif // TLRENDER_API_GL_4_1_Debug
         }
 
+        void windowHint(int flag, int value)
+        {
+            if (!gl::isWayland())
+            {
+                glfwWindowHint(flag, value);
+            }
+            else
+            {
+                // \@bug: NVidia drivers currently return EGL error if
+                //        GLFW_DOUBLEBUFFER is GLFW_FALSE
+                if (flag == GLFW_DOUBLEBUFFER)
+                {
+                    glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_TRUE);
+                }
+            }
+        }
+        
         struct GLFWWindow::Private
         {
             std::weak_ptr<system::Context> context;
@@ -101,9 +119,10 @@ namespace tl
             glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
             glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_ANY_PROFILE);
 #endif // TLRENDER_API_GL_4_1
+
             glfwWindowHint(GLFW_VISIBLE,
                 options & static_cast<int>(GLFWWindowOptions::Visible));
-            glfwWindowHint(GLFW_DOUBLEBUFFER,
+            gl::windowHint(GLFW_DOUBLEBUFFER, 
                 options & static_cast<int>(GLFWWindowOptions::DoubleBuffer));
 #if defined(TLRENDER_API_GL_4_1_Debug)
             glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);

--- a/lib/tlGL/GLFWWindow.h
+++ b/lib/tlGL/GLFWWindow.h
@@ -27,6 +27,8 @@ namespace tl
             MakeCurrent  = 4
         };
 
+        void windowHint(int flag, int value);
+        
         //! GLFW window wrapper.
         class GLFWWindow : public std::enable_shared_from_this<GLFWWindow>
         {

--- a/lib/tlIO/USDRender.cpp
+++ b/lib/tlIO/USDRender.cpp
@@ -9,6 +9,8 @@
 #include <tlCore/LogSystem.h>
 #include <tlCore/StringFormat.h>
 
+#include <tlGL/GLFWWindow.h>
+
 #include <pxr/pxr.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/token.h>
@@ -118,7 +120,7 @@ namespace tl
             glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
             glfwWindowHint(GLFW_OPENGL_PROFILE, glProfile);
             glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
-            glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_FALSE);
+            gl::windowHint(GLFW_DOUBLEBUFFER, GLFW_FALSE);
             p.glfwWindow = glfwCreateWindow(1, 1, "tl::usd::Render", NULL, NULL);
             if (!p.glfwWindow)
             {


### PR DESCRIPTION
Under GLFW 3.4 and Wayland you currently cannot have single buffer windows. It appears to be a GLFW bug, as FLTK allows it.