### PR TITLE
Bump minizip-ng from 3.0.7 to 4.0.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 find_package(Imath REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(ZLIB REQUIRED)
-find_package(minizip REQUIRED)
+find_package(minizip-ng REQUIRED)
 find_package(OpenTimelineIO REQUIRED)
 
 # OpenColorIO dependencies

--- a/etc/SuperBuild/cmake/Modules/Buildminizip-ng.cmake
+++ b/etc/SuperBuild/cmake/Modules/Buildminizip-ng.cmake
@@ -1,9 +1,10 @@
 include(ExternalProject)
 
 set(minizip-ng_GIT_REPOSITORY "https://github.com/zlib-ng/minizip-ng.git")
-set(minizip-ng_GIT_TAG "3.0.7")
+set(minizip-ng_GIT_TAG "4.0.10")
 
 set(minizip-ng_ARGS
+    -DMZ_COMPAT=OFF
     -DMZ_BZIP2=OFF
     -DMZ_LZMA=OFF
     -DMZ_ZSTD=OFF

--- a/etc/SuperBuild/tests/OpenColorIOTest/CMakeLists.txt
+++ b/etc/SuperBuild/tests/OpenColorIOTest/CMakeLists.txt
@@ -1,10 +1,10 @@
 find_package(ZLIB REQUIRED)
-find_package(minizip REQUIRED)
+find_package(minizip-ng REQUIRED)
 find_package(OpenColorIO REQUIRED)
 
 set(source main.cpp)
 
 add_executable(OpenColorIOTest ${header} ${source})
-target_link_libraries(OpenColorIOTest OpenColorIO::OpenColorIO MINIZIP::minizip ZLIB::ZLIB)
+target_link_libraries(OpenColorIOTest OpenColorIO::OpenColorIO MINIZIP::minizip-ng ZLIB::ZLIB)
 
 add_test(OpenColorIOTest OpenColorIOTest)

--- a/lib/tlCore/CMakeLists.txt
+++ b/lib/tlCore/CMakeLists.txt
@@ -40,7 +40,7 @@ else()
 endif()
 
 set(LIBRARIES tlResource ftk::feather-tk-core OTIO::opentimelineio Imath::Imath nlohmann_json::nlohmann_json)
-set(LIBRARIES_PRIVATE Freetype::Freetype MINIZIP::minizip ZLIB::ZLIB)
+set(LIBRARIES_PRIVATE Freetype::Freetype MINIZIP::minizip-ng ZLIB::ZLIB)
 if(TLRENDER_OCIO)
     list(APPEND LIBRARIES OpenColorIO::OpenColorIO)
 endif()

--- a/lib/tlTimeline/CMakeLists.txt
+++ b/lib/tlTimeline/CMakeLists.txt
@@ -47,7 +47,7 @@ set(SOURCE
     Video.cpp)
 
 add_library(tlTimeline ${HEADERS} ${PRIVATE_HEADERS} ${SOURCE})
-target_link_libraries(tlTimeline tlIO)
+target_link_libraries(tlTimeline tlIO MINIZIP::minizip-ng)
 set_target_properties(tlTimeline PROPERTIES FOLDER lib)
 set_target_properties(tlTimeline PROPERTIES PUBLIC_HEADER "${HEADERS}")
 

--- a/lib/tlTimeline/TimelineCreate.cpp
+++ b/lib/tlTimeline/TimelineCreate.cpp
@@ -99,7 +99,7 @@ namespace tl
         public:
             ZipReader(const std::string& fileName)
             {
-                mz_zip_reader_create(&reader);
+                reader = mz_zip_reader_create();
                 if (!reader)
                 {
                     throw std::runtime_error(ftk::Format(

--- a/lib/tlTimeline/Util.cpp
+++ b/lib/tlTimeline/Util.cpp
@@ -662,7 +662,7 @@ namespace tl
                 }
 
                 // Open the output file.
-                mz_zip_writer_create(&_writer);
+                _writer = mz_zip_writer_create();
                 if (!_writer)
                 {
                     throw std::runtime_error(ftk::Format("Cannot create writer: \"{0}\"").arg(fileName));

--- a/tlRenderConfig.cmake.in
+++ b/tlRenderConfig.cmake.in
@@ -9,7 +9,7 @@ include(CMakeFindDependencyMacro)
 find_package(Imath REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(ZLIB REQUIRED)
-find_package(minizip REQUIRED)
+find_package(minizip-ng REQUIRED)
 find_package(OpenTimelineIO REQUIRED)
 
 # OpenColorIO dependencies


### PR DESCRIPTION
This PR bump minizip-ng from 3.0.7 to 4.0.10

minizip-ng v4.0.0 was released in 2023, introduced [an API change](https://github.com/zlib-ng/minizip-ng/releases/tag/4.0.0): Functions ending in _create( will no longer accept a first parameter. This forces a single way to get a pointer to new object and is more likely to result in a check of its value.

And the CMake target `MINIZIP::minizip` is [an alias](https://github.com/zlib-ng/minizip-ng/blob/1867916bec205bb16299b7abe7145539eef6fb8a/CMakeLists.txt#L694-L699) of `MINIZIP::minizip-ng`, and which is not available if compat mode not enabled.

