### PR TITLE
Fix FFmpeg command paths on Windows

### DIFF
--- a/lib/tlRender/IO/FFmpegCmd.cpp
+++ b/lib/tlRender/IO/FFmpegCmd.cpp
@@ -10,10 +10,71 @@
 
 #include <regex>
 
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif // WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif // NOMINMAX
+#include <Windows.h>
+#endif
+
 namespace tl
 {
     namespace ffmpeg_cmd
     {
+#if defined(_WIN32)
+        namespace
+        {
+            std::string toSubprocessArg(const std::string& value)
+            {
+                if (value.empty())
+                {
+                    return value;
+                }
+
+                // subprocess.h uses CreateProcessA on Windows. Convert tlRender's
+                // UTF-8 strings to the active ANSI code page before handing off so
+                // CreateProcessA reconstructs the intended wide command line.
+                const std::wstring wide = ftk::toWide(value);
+                const int size = WideCharToMultiByte(
+                    CP_ACP,
+                    0,
+                    wide.c_str(),
+                    -1,
+                    nullptr,
+                    0,
+                    nullptr,
+                    nullptr);
+                if (size <= 0)
+                {
+                    return value;
+                }
+
+                std::string out(size, 0);
+                const int written = WideCharToMultiByte(
+                    CP_ACP,
+                    0,
+                    wide.c_str(),
+                    -1,
+                    out.data(),
+                    size,
+                    nullptr,
+                    nullptr);
+                if (written <= 0)
+                {
+                    return value;
+                }
+                if (!out.empty() && '\0' == out.back())
+                {
+                    out.pop_back();
+                }
+                return out;
+            }
+        }
+#endif
+
         Options::Options(const IOOptions& value)
         {
             auto i = value.find("FFmpeg/FFmpegPath");
@@ -154,8 +215,17 @@ namespace tl
             _p(new Private)
         {
             FTK_P();
+#if defined(_WIN32)
+            std::vector<std::string> command = cmd;
+            for (auto& i : command)
+            {
+                i = toSubprocessArg(i);
+            }
+#else
+            const auto& command = cmd;
+#endif
             std::vector<const char*> args;
-            for (const auto& i : cmd)
+            for (const auto& i : command)
             {
                 args.push_back(i.c_str());
             }


### PR DESCRIPTION
## Summary
- Convert FFmpeg command arguments from tlRender's UTF-8 strings to the active Windows ANSI code page before passing them to subprocess.h.
- This avoids mojibake when subprocess.h calls CreateProcessA on Windows and the media path contains characters such as accents.

## Why
DJV/tlRender can pass UTF-8 media paths to ffprobe/ffmpeg. On Windows, the current subprocess.h dependency uses CreateProcessA, so those UTF-8 bytes are interpreted as the process ANSI code page before the child process sees the command line. Paths like `G:\Drive partagés\JJJ\› Storyboard\file.mp4` become mojibake and ffprobe fails to find the file.

## Validation
- Reproduced locally with DJV 3.4.2: the same MP4 fails from its original non-ASCII directory and opens correctly from an ASCII alias path.
- Verified `ffprobe` itself can read the original non-ASCII path from PowerShell.
- Simulated CreateProcessA locally:
  - ACP-encoded command line exit code: 0
  - UTF-8 bytes interpreted through CreateProcessA exit code: 1
- Ran `git diff --check`.

## Notes
This is a minimal compatibility fix for the existing subprocess.h/CreateProcessA path. A fuller long-term fix would be to move subprocess creation to CreateProcessW so all Unicode paths are handled independently of the active ANSI code page.