### PR TITLE
Fix native FFmpeg .m4v input extension

### DIFF
--- a/lib/tlRender/IO/FFmpeg.cpp
+++ b/lib/tlRender/IO/FFmpeg.cpp
@@ -217,6 +217,7 @@ namespace tl
                 }
             }
             //! \bug Why aren't these in the list of input formats?
+            extensions[".m4v"] = FileType::Media;
             extensions[".mxf"] = FileType::Media;
             extensions[".wav"] = FileType::Media;
 


### PR DESCRIPTION
## Summary
- register `.m4v` as a media input extension for the native FFmpeg plugin
- keep it next to the other manually added FFmpeg input extensions

## Why
Some FFmpeg/libavformat builds expose MOV/MP4 inputs without listing `.m4v` as an input extension. In that case the native FFmpeg plugin can read related containers but tlRender/DJV may fail to route `.m4v` files to FFmpeg.

## Verification
- Built and installed tlRender on Windows Release:
  `cmake --build C:\dja\sbuild-Release\tl\src\tl-build --config Release --target install`
- Re-linked DJV against that tlRender install:
  `cmake --build C:\Users\Nathan\Documents\Code\DJV\build-dja-Release --config Release --target djv`
- Opened `.m4v` samples in DJV and verified they create a timeline/player and cache video without `Cannot read timeline`.