### PR TITLE
Add selected-in alignment and frame offset for relative compare playback

### DIFF
--- a/lib/tlRender/Timeline/CompareOptions.cpp
+++ b/lib/tlRender/Timeline/CompareOptions.cpp
@@ -32,6 +32,18 @@ namespace tl
         "Relative",
         "Absolute");
 
+    bool CompareTimeOptions::operator == (const CompareTimeOptions& other) const
+    {
+        return
+            alignInPoints == other.alignInPoints &&
+            frameOffset == other.frameOffset;
+    }
+
+    bool CompareTimeOptions::operator != (const CompareTimeOptions& other) const
+    {
+        return !(*this == other);
+    }
+
     namespace
     {
         //! Get the image information used to lay out each video frame, taken
@@ -291,6 +303,45 @@ namespace tl
                 floor();
             break;
         default: break;
+        }
+        return out;
+    }
+
+    OTIO_NS::RationalTime getCompareTime(
+        const OTIO_NS::RationalTime& sourceTime,
+        const OTIO_NS::TimeRange& sourceTimeRange,
+        const OTIO_NS::TimeRange& compareTimeRange,
+        CompareTime compare,
+        const OTIO_NS::TimeRange& sourceInOutRange,
+        const OTIO_NS::TimeRange& compareInOutRange,
+        const CompareTimeOptions& options)
+    {
+        OTIO_NS::RationalTime out = getCompareTime(
+            sourceTime,
+            sourceTimeRange,
+            compareTimeRange,
+            compare);
+        if (CompareTime::Relative == compare)
+        {
+            const double compareRate = compareTimeRange.duration().rate();
+            if (options.alignInPoints)
+            {
+                const OTIO_NS::RationalTime sourceInOffset =
+                    (sourceInOutRange.start_time() - sourceTimeRange.start_time()).
+                    rescaled_to(compareRate).
+                    floor();
+                const OTIO_NS::RationalTime compareInOffset =
+                    (compareInOutRange.start_time() - compareTimeRange.start_time()).
+                    rescaled_to(compareRate).
+                    floor();
+                out = out + sourceInOffset - compareInOffset;
+            }
+            if (options.frameOffset)
+            {
+                out = out + OTIO_NS::RationalTime(
+                    options.frameOffset,
+                    compareRate);
+            }
         }
         return out;
     }

--- a/lib/tlRender/Timeline/CompareOptions.h
+++ b/lib/tlRender/Timeline/CompareOptions.h
@@ -38,6 +38,19 @@ namespace tl
     };
     TL_ENUM(CompareTime);
 
+    //! Options for mapping relative comparison time.
+    struct TL_API_TYPE CompareTimeOptions
+    {
+        //! Align the selected in points instead of the full timeline starts.
+        bool alignInPoints = false;
+
+        //! Additional frame offset applied to the comparison timeline.
+        int frameOffset = 0;
+
+        TL_API bool operator == (const CompareTimeOptions&) const;
+        TL_API bool operator != (const CompareTimeOptions&) const;
+    };
+
     //! Comparison options.
     struct TL_API_TYPE CompareOptions
     {
@@ -87,6 +100,17 @@ namespace tl
         const OTIO_NS::TimeRange& sourceTimeRange,
         const OTIO_NS::TimeRange& compareTimeRange,
         CompareTime);
+
+    //! Get a compare time with optional selected-in alignment and frame offset.
+    //! The additional options are applied only to relative comparison time.
+    TL_API OTIO_NS::RationalTime getCompareTime(
+        const OTIO_NS::RationalTime& sourceTime,
+        const OTIO_NS::TimeRange& sourceTimeRange,
+        const OTIO_NS::TimeRange& compareTimeRange,
+        CompareTime,
+        const OTIO_NS::TimeRange& sourceInOutRange,
+        const OTIO_NS::TimeRange& compareInOutRange,
+        const CompareTimeOptions&);
 
     //! \name Serialize
     ///@{

--- a/lib/tlRender/Timeline/Player.cpp
+++ b/lib/tlRender/Timeline/Player.cpp
@@ -106,7 +106,9 @@ namespace tl
         p.seek = ftk::Observable<OTIO_NS::RationalTime>::create(p.currentTime->get());
         p.inOutRange = ftk::Observable<OTIO_NS::TimeRange>::create(p.timeRange);
         p.compare = ftk::ObservableList<std::shared_ptr<Timeline> >::create();
+        p.compareInOutRanges = ftk::Observable<std::vector<OTIO_NS::TimeRange> >::create();
         p.compareTime = ftk::Observable<CompareTime>::create(CompareTime::Relative);
+        p.compareTimeOptions = ftk::Observable<CompareTimeOptions>::create();
         p.ioOptions = ftk::Observable<IOOptions>::create();
         p.mediaReferenceKey = ftk::Observable<std::string>::create(
             timeline->getMediaReferenceKey());
@@ -162,6 +164,8 @@ namespace tl
         // Create a new thread.
         p.mutex.state.currentTime = p.currentTime->get();
         p.mutex.state.inOutRange = p.inOutRange->get();
+        p.mutex.state.compareInOutRanges = p.compareInOutRanges->get();
+        p.mutex.state.compareTimeOptions = p.compareTimeOptions->get();
         p.mutex.state.audioOffset = p.audioOffset->get();
         p.mutex.state.cacheOptions = p.cacheOptions->get();
         p.audioMutex.state.speed = p.speed->get() * p.speedMult->get();
@@ -645,6 +649,10 @@ namespace tl
             std::unique_lock<std::mutex> lock(p.mutex.mutex);
             p.mutex.state.inOutRange = tmp;
             p.mutex.clearRequests = true;
+            if (p.compareTimeOptions->get().alignInPoints)
+            {
+                p.mutex.clearCache = true;
+            }
         }
     }
 
@@ -708,6 +716,31 @@ namespace tl
         }
     }
 
+    const std::vector<OTIO_NS::TimeRange>& Player::getCompareInOutRanges() const
+    {
+        return _p->compareInOutRanges->get();
+    }
+
+    std::shared_ptr<ftk::IObservable<std::vector<OTIO_NS::TimeRange> > > Player::observeCompareInOutRanges() const
+    {
+        return _p->compareInOutRanges;
+    }
+
+    void Player::setCompareInOutRanges(const std::vector<OTIO_NS::TimeRange>& value)
+    {
+        FTK_P();
+        if (p.compareInOutRanges->setIfChanged(value))
+        {
+            std::unique_lock<std::mutex> lock(p.mutex.mutex);
+            p.mutex.state.compareInOutRanges = value;
+            p.mutex.clearRequests = true;
+            if (p.compareTimeOptions->get().alignInPoints)
+            {
+                p.mutex.clearCache = true;
+            }
+        }
+    }
+
     CompareTime Player::getCompareTime() const
     {
         return _p->compareTime->get();
@@ -725,6 +758,28 @@ namespace tl
         {
             std::unique_lock<std::mutex> lock(p.mutex.mutex);
             p.mutex.state.compareTime = value;
+            p.mutex.clearRequests = true;
+            p.mutex.clearCache = true;
+        }
+    }
+
+    const CompareTimeOptions& Player::getCompareTimeOptions() const
+    {
+        return _p->compareTimeOptions->get();
+    }
+
+    std::shared_ptr<ftk::IObservable<CompareTimeOptions> > Player::observeCompareTimeOptions() const
+    {
+        return _p->compareTimeOptions;
+    }
+
+    void Player::setCompareTimeOptions(const CompareTimeOptions& value)
+    {
+        FTK_P();
+        if (p.compareTimeOptions->setIfChanged(value))
+        {
+            std::unique_lock<std::mutex> lock(p.mutex.mutex);
+            p.mutex.state.compareTimeOptions = value;
             p.mutex.clearRequests = true;
             p.mutex.clearCache = true;
         }

--- a/lib/tlRender/Timeline/Player.h
+++ b/lib/tlRender/Timeline/Player.h
@@ -276,6 +276,15 @@ namespace tl
         //! Set the timelines for comparison.
         TL_API void setCompare(const std::vector<std::shared_ptr<Timeline> >&);
 
+        //! Get the selected in/out ranges for the comparison timelines.
+        TL_API const std::vector<OTIO_NS::TimeRange>& getCompareInOutRanges() const;
+
+        //! Observe the selected in/out ranges for the comparison timelines.
+        TL_API std::shared_ptr<ftk::IObservable<std::vector<OTIO_NS::TimeRange> > > observeCompareInOutRanges() const;
+
+        //! Set the selected in/out ranges for the comparison timelines.
+        TL_API void setCompareInOutRanges(const std::vector<OTIO_NS::TimeRange>&);
+
         //! Get the comparison time mode.
         TL_API CompareTime getCompareTime() const;
 
@@ -284,6 +293,15 @@ namespace tl
 
         //! Set the comparison time mode.
         TL_API void setCompareTime(CompareTime);
+
+        //! Get the relative comparison time options.
+        TL_API const CompareTimeOptions& getCompareTimeOptions() const;
+
+        //! Observe the relative comparison time options.
+        TL_API std::shared_ptr<ftk::IObservable<CompareTimeOptions> > observeCompareTimeOptions() const;
+
+        //! Set the relative comparison time options.
+        TL_API void setCompareTimeOptions(const CompareTimeOptions&);
 
         ///@}
 

--- a/lib/tlRender/Timeline/PlayerPrivate.cpp
+++ b/lib/tlRender/Timeline/PlayerPrivate.cpp
@@ -361,11 +361,23 @@ namespace tl
 
                         for (size_t k = 0; k < thread.state.compare.size(); ++k)
                         {
+                            const OTIO_NS::TimeRange compareTimeRange =
+                                thread.state.compare[k]->getTimeRange();
+                            const OTIO_NS::TimeRange compareInOutRange =
+                                k < thread.state.compareInOutRanges.size() &&
+                                !tl::compareExact(
+                                    thread.state.compareInOutRanges[k],
+                                    invalidTimeRange) ?
+                                thread.state.compareInOutRanges[k] :
+                                compareTimeRange;
                             const OTIO_NS::RationalTime t2 = tl::getCompareTime(
                                 timeLooped,
                                 timeRange,
-                                thread.state.compare[k]->getTimeRange(),
-                                thread.state.compareTime);
+                                compareTimeRange,
+                                thread.state.compareTime,
+                                thread.state.inOutRange,
+                                compareInOutRange,
+                                thread.state.compareTimeOptions);
                             ioOptions2["Layer"] = ftk::Format("{0}").
                                 arg(k < thread.state.compareVideoLayers.size() ?
                                     thread.state.compareVideoLayers[k] :

--- a/lib/tlRender/Timeline/PlayerPrivate.h
+++ b/lib/tlRender/Timeline/PlayerPrivate.h
@@ -74,7 +74,9 @@ namespace tl
         std::shared_ptr<ftk::Observable<OTIO_NS::RationalTime> > seek;
         std::shared_ptr<ftk::Observable<OTIO_NS::TimeRange> > inOutRange;
         std::shared_ptr<ftk::ObservableList<std::shared_ptr<Timeline> > > compare;
+        std::shared_ptr<ftk::Observable<std::vector<OTIO_NS::TimeRange> > > compareInOutRanges;
         std::shared_ptr<ftk::Observable<CompareTime> > compareTime;
+        std::shared_ptr<ftk::Observable<CompareTimeOptions> > compareTimeOptions;
         std::shared_ptr<ftk::Observable<IOOptions> > ioOptions;
         std::shared_ptr<ftk::Observable<std::string> > mediaReferenceKey;
         std::shared_ptr<ftk::Observable<int> > videoLayer;
@@ -132,7 +134,9 @@ namespace tl
             OTIO_NS::RationalTime currentTime = invalidTime;
             OTIO_NS::TimeRange inOutRange = invalidTimeRange;
             std::vector<std::shared_ptr<Timeline> > compare;
+            std::vector<OTIO_NS::TimeRange> compareInOutRanges;
             CompareTime compareTime = CompareTime::Relative;
+            CompareTimeOptions compareTimeOptions;
             IOOptions ioOptions;
             int videoLayer = 0;
             std::vector<int> compareVideoLayers;

--- a/lib/tlRender/TimelineTest/CompareOptionsTest.cpp
+++ b/lib/tlRender/TimelineTest/CompareOptionsTest.cpp
@@ -107,6 +107,41 @@ namespace tl
                     CompareTime::Relative);
                 FTK_ASSERT(time == OTIO_NS::RationalTime(24.0, 24.0));
             }
+            {
+                CompareTimeOptions options;
+                options.alignInPoints = true;
+                options.frameOffset = 2;
+                FTK_ASSERT(options != CompareTimeOptions());
+                const OTIO_NS::TimeRange sourceRange(
+                    OTIO_NS::RationalTime(0.0, 24.0),
+                    OTIO_NS::RationalTime(240.0, 24.0));
+                const OTIO_NS::TimeRange compareRange(
+                    OTIO_NS::RationalTime(100.0, 24.0),
+                    OTIO_NS::RationalTime(240.0, 24.0));
+                const auto time = getCompareTime(
+                    OTIO_NS::RationalTime(20.0, 24.0),
+                    sourceRange,
+                    compareRange,
+                    CompareTime::Relative,
+                    OTIO_NS::TimeRange(
+                        OTIO_NS::RationalTime(10.0, 24.0),
+                        OTIO_NS::RationalTime(100.0, 24.0)),
+                    OTIO_NS::TimeRange(
+                        OTIO_NS::RationalTime(130.0, 24.0),
+                        OTIO_NS::RationalTime(100.0, 24.0)),
+                    options);
+                FTK_ASSERT(time == OTIO_NS::RationalTime(102.0, 24.0));
+
+                const auto absoluteTime = getCompareTime(
+                    OTIO_NS::RationalTime(20.0, 24.0),
+                    sourceRange,
+                    compareRange,
+                    CompareTime::Absolute,
+                    sourceRange,
+                    compareRange,
+                    options);
+                FTK_ASSERT(absoluteTime == OTIO_NS::RationalTime(20.0, 24.0));
+            }
         }
     }
 }

--- a/lib/tlRender/TimelineTest/PlayerTest.cpp
+++ b/lib/tlRender/TimelineTest/PlayerTest.cpp
@@ -224,6 +224,42 @@ namespace tl
             player->resetOutPoint();
             FTK_ASSERT(OTIO_NS::TimeRange(timeRange.start_time(), timeRange.duration()) == inOutRange);
 
+            // Test the comparison time options.
+            std::vector<OTIO_NS::TimeRange> compareInOutRanges;
+            auto compareInOutRangesObserver =
+                ftk::Observer<std::vector<OTIO_NS::TimeRange> >::create(
+                    player->observeCompareInOutRanges(),
+                    [&compareInOutRanges](const std::vector<OTIO_NS::TimeRange>& value)
+                    {
+                        compareInOutRanges = value;
+                    });
+            const std::vector<OTIO_NS::TimeRange> compareInOutRanges2 =
+            {
+                OTIO_NS::TimeRange(
+                    timeRange.start_time(),
+                    OTIO_NS::RationalTime(10.0, rate))
+            };
+            player->setCompareInOutRanges(compareInOutRanges2);
+            FTK_ASSERT(compareInOutRanges2 == player->getCompareInOutRanges());
+            FTK_ASSERT(compareInOutRanges2 == compareInOutRanges);
+
+            CompareTimeOptions compareTimeOptions;
+            auto compareTimeOptionsObserver =
+                ftk::Observer<CompareTimeOptions>::create(
+                    player->observeCompareTimeOptions(),
+                    [&compareTimeOptions](const CompareTimeOptions& value)
+                    {
+                        compareTimeOptions = value;
+                    });
+            CompareTimeOptions compareTimeOptions2;
+            compareTimeOptions2.alignInPoints = true;
+            compareTimeOptions2.frameOffset = 2;
+            player->setCompareTimeOptions(compareTimeOptions2);
+            FTK_ASSERT(compareTimeOptions2 == player->getCompareTimeOptions());
+            FTK_ASSERT(compareTimeOptions2 == compareTimeOptions);
+            player->setCompareInOutRanges({});
+            player->setCompareTimeOptions({});
+
             // Test the I/O options.
             IOOptions ioOptions;
             auto ioOptionsObserver = ftk::Observer<IOOptions>::create(


### PR DESCRIPTION
## Summary
- add optional relative compare-time alignment using the selected in points of A and each comparison timeline
- add a frame offset expressed at the comparison timeline rate
- keep current behavior as the default and leave absolute comparison time unchanged
- publish compare range/options changes safely to the player cache thread

## Tests added
- selected-in alignment plus frame offset math
- absolute-mode compatibility
- Player observable/setter coverage for compare ranges and options

## Verification
- `git diff --check` passes
- the changed timeline sources are parsed and compiled up to an unrelated pre-existing local dependency failure in existing `PlayerPrivate::log()` formatting

## Notes
This is a draft. The full local test executable is currently blocked by the local OpenTimelineIO 0.18/nlohmann combination in unmodified tlRender time serialization/formatting code, before the new tests can link and run.