### PR TITLE
Add independent zoom controls for tile comparison

### DIFF
--- a/lib/tlRender/GL/Render.h
+++ b/lib/tlRender/GL/Render.h
@@ -166,7 +166,8 @@ namespace tl
                 const ftk::Box2I&,
                 const std::shared_ptr<ftk::ImageOptions>&,
                 const DisplayOptions&,
-                ftk::gl::TextureType colorBuffer);
+                ftk::gl::TextureType colorBuffer,
+                double tileZoom = 1.0);
 
             FTK_PRIVATE();
         };

--- a/lib/tlRender/GL/RenderVideo.cpp
+++ b/lib/tlRender/GL/RenderVideo.cpp
@@ -661,7 +661,10 @@ namespace tl
                     boxes[i],
                     i < imageOptions.size() ? std::make_shared<ftk::ImageOptions>(imageOptions[i]) : nullptr,
                     i < displayOptions.size() ? displayOptions[i] : DisplayOptions(),
-                    colorBuffer);
+                    colorBuffer,
+                    Compare::Tile == compareOptions.compare ?
+                        getTileZoom(compareOptions, i) :
+                        1.0);
             }
         }
         
@@ -702,7 +705,8 @@ namespace tl
             const ftk::Box2I& box,
             const std::shared_ptr<ftk::ImageOptions>& imageOptions,
             const DisplayOptions& displayOptions,
-            ftk::gl::TextureType colorBuffer)
+            ftk::gl::TextureType colorBuffer,
+            double tileZoom)
         {
             FTK_P();
             
@@ -726,7 +730,7 @@ namespace tl
             // OTIO spatial coordinates a layer fills the buffer as before;
             // with them it keeps its place in the timeline canvas, scaled to
             // the buffer.
-            const auto layerBox = [&videoFrame, &offscreenBufferSize](
+            const auto layerBox = [&videoFrame, &offscreenBufferSize, tileZoom](
                 const std::optional<ftk::Box2F>& bounds)
             {
                 ftk::Box2I out(ftk::V2I(), offscreenBufferSize);
@@ -744,7 +748,10 @@ namespace tl
                             std::lround(bounds.value().max.x * sx),
                             std::lround(bounds.value().max.y * sy)));
                 }
-                return out;
+                return getTileZoomBox(
+                    out,
+                    ftk::Box2I(ftk::V2I(), offscreenBufferSize),
+                    tileZoom);
             };
 
             ftk::gl::OffscreenBufferOptions offscreenBufferOptions;

--- a/lib/tlRender/Timeline/CompareOptions.cpp
+++ b/lib/tlRender/Timeline/CompareOptions.cpp
@@ -81,12 +81,41 @@ namespace tl
             wipeCenter == other.wipeCenter &&
             wipeRotation == other.wipeRotation &&
             overlay == other.overlay &&
-            fitToA == other.fitToA;
+            fitToA == other.fitToA &&
+            tileZoomSync == other.tileZoomSync &&
+            tileZooms == other.tileZooms;
     }
 
     bool CompareOptions::operator != (const CompareOptions& other) const
     {
         return !(*this == other);
+    }
+
+    double getTileZoom(const CompareOptions& options, size_t index)
+    {
+        return
+            index < options.tileZooms.size() &&
+            options.tileZooms[index] > 0.0 ?
+            options.tileZooms[index] :
+            1.0;
+    }
+
+    ftk::Box2I getTileZoomBox(
+        const ftk::Box2I& box,
+        const ftk::Box2I& tile,
+        double zoom)
+    {
+        const double value = zoom > 0.0 ? zoom : 1.0;
+        const ftk::V2F center(
+            tile.x() + tile.w() / 2.F,
+            tile.y() + tile.h() / 2.F);
+        const ftk::V2I min(
+            std::lround(center.x + (box.min.x - center.x) * value),
+            std::lround(center.y + (box.min.y - center.y) * value));
+        const ftk::Size2I size(
+            std::lround(box.w() * value),
+            std::lround(box.h() * value));
+        return ftk::Box2I(min, size);
     }
 
     std::vector<ftk::Box2I> getBounds(
@@ -218,6 +247,14 @@ namespace tl
         return out;
     }
 
+    std::vector<ftk::Box2I> getBounds(
+        const CompareOptions& options,
+        const AspectRatioOptions& aspectRatioOptions,
+        const std::vector<VideoFrame>& videoFrame)
+    {
+        return getBounds(options, aspectRatioOptions, getInfos(videoFrame));
+    }
+
     std::vector<ftk::Box2I> getBoxes(
         const CompareOptions& options,
         const AspectRatioOptions& aspectRatioOptions,
@@ -302,6 +339,8 @@ namespace tl
         json["WipeRotation"] = in.wipeRotation;
         json["Overlay"] = in.overlay;
         json["FitToA"] = in.fitToA;
+        json["TileZoomSync"] = in.tileZoomSync;
+        json["TileZooms"] = in.tileZooms;
     }
 
     void from_json(const nlohmann::json& json, CompareOptions& out)
@@ -311,5 +350,13 @@ namespace tl
         json.at("WipeRotation").get_to(out.wipeRotation);
         json.at("Overlay").get_to(out.overlay);
         json.at("FitToA").get_to(out.fitToA);
+        if (json.contains("TileZoomSync"))
+        {
+            json.at("TileZoomSync").get_to(out.tileZoomSync);
+        }
+        if (json.contains("TileZooms"))
+        {
+            json.at("TileZooms").get_to(out.tileZooms);
+        }
     }
 }

--- a/lib/tlRender/Timeline/CompareOptions.h
+++ b/lib/tlRender/Timeline/CompareOptions.h
@@ -46,16 +46,33 @@ namespace tl
         float    wipeRotation = 0.F;
         float    overlay      = .5F;
         bool     fitToA       = true;
+        bool     tileZoomSync = true;
+        std::vector<double> tileZooms;
 
         TL_API bool operator == (const CompareOptions&) const;
         TL_API bool operator != (const CompareOptions&) const;
     };
+
+    //! Get the zoom for a tile. Missing entries use the neutral zoom.
+    TL_API double getTileZoom(const CompareOptions&, size_t);
+
+    //! Scale a box around the center of its tile.
+    TL_API ftk::Box2I getTileZoomBox(
+        const ftk::Box2I&,
+        const ftk::Box2I& tile,
+        double zoom);
 
     //! Get the bounds for the given compare mode.
     TL_API std::vector<ftk::Box2I> getBounds(
         const CompareOptions&,
         const AspectRatioOptions&,
         const std::vector<ftk::ImageInfo>&);
+
+    //! Get the bounds for the given compare mode.
+    TL_API std::vector<ftk::Box2I> getBounds(
+        const CompareOptions&,
+        const AspectRatioOptions&,
+        const std::vector<VideoFrame>&);
 
     //! Get the boxes for the given compare mode.
     TL_API std::vector<ftk::Box2I> getBoxes(

--- a/lib/tlRender/TimelineTest/CompareOptionsTest.cpp
+++ b/lib/tlRender/TimelineTest/CompareOptionsTest.cpp
@@ -35,6 +35,37 @@ namespace tl
                 FTK_ASSERT(options != CompareOptions());
             }
             {
+                CompareOptions options;
+                options.compare = Compare::Tile;
+                options.tileZoomSync = false;
+                options.tileZooms = { 1.0, 2.0 };
+                FTK_ASSERT(1.0 == getTileZoom(options, 0));
+                FTK_ASSERT(2.0 == getTileZoom(options, 1));
+                FTK_ASSERT(1.0 == getTileZoom(options, 2));
+                FTK_ASSERT(
+                    ftk::Box2I(-50, -50, 200, 200) ==
+                    getTileZoomBox(
+                        ftk::Box2I(0, 0, 100, 100),
+                        ftk::Box2I(0, 0, 100, 100),
+                        2.0));
+                FTK_ASSERT(
+                    ftk::Box2I(25, 25, 50, 50) ==
+                    getTileZoomBox(
+                        ftk::Box2I(0, 0, 100, 100),
+                        ftk::Box2I(0, 0, 100, 100),
+                        .5));
+
+                nlohmann::json json = options;
+                const CompareOptions roundTrip = json.get<CompareOptions>();
+                FTK_ASSERT(options == roundTrip);
+
+                json.erase("TileZoomSync");
+                json.erase("TileZooms");
+                const CompareOptions legacy = json.get<CompareOptions>();
+                FTK_ASSERT(legacy.tileZoomSync);
+                FTK_ASSERT(legacy.tileZooms.empty());
+            }
+            {
                 const std::vector<ftk::ImageInfo> infos =
                 {
                     ftk::ImageInfo(1920, 1080, ftk::ImageType::RGBA_U8),

--- a/lib/tlRender/UI/Viewport.cpp
+++ b/lib/tlRender/UI/Viewport.cpp
@@ -35,6 +35,8 @@ namespace tl
             std::shared_ptr<ftk::Observable<double> > zoom;
             ftk::RangeD zoomRange = ftk::RangeD(0.01, 512.0);
             std::shared_ptr<ftk::Observable<std::pair<ftk::V2I, double> > > viewPosZoom;
+            std::shared_ptr<ftk::Observable<double> > tileZoom;
+            size_t activeTile = 0;
             std::shared_ptr<ftk::Observable<bool> > frameView;
             std::shared_ptr<ftk::Observable<bool> > framed;
             std::shared_ptr<ftk::Observable<double> > fps;
@@ -109,6 +111,7 @@ namespace tl
             p.zoom = ftk::Observable<double>::create(1.0);
             p.viewPosZoom = ftk::Observable<std::pair<ftk::V2I, double> >::create(
                 std::make_pair(ftk::V2I(), 1.0));
+            p.tileZoom = ftk::Observable<double>::create(1.0);
             p.frameView = ftk::Observable<bool>::create(true);
             p.framed = ftk::Observable<bool>::create(false);
             p.fps = ftk::Observable<double>::create(0.0);
@@ -146,6 +149,7 @@ namespace tl
             FTK_P();
             if (p.compareOptions->setIfChanged(value))
             {
+                p.tileZoom->setIfChanged(tl::getTileZoom(value, p.activeTile));
                 p.doRender = true;
                 setDrawUpdate();
             }
@@ -337,6 +341,12 @@ namespace tl
                     {
                         FTK_P();
                         p.videoFrame = value;
+                        if (p.activeTile >= p.videoFrame.size())
+                        {
+                            p.activeTile = 0;
+                        }
+                        p.tileZoom->setIfChanged(
+                            tl::getTileZoom(p.compareOptions->get(), p.activeTile));
 
                         if (p.fpsData.has_value())
                         {
@@ -432,6 +442,60 @@ namespace tl
             setViewPosAndZoom(pos, zoomClamped);
         }
 
+        double Viewport::getTileZoom() const
+        {
+            return _p->tileZoom->get();
+        }
+
+        std::shared_ptr<ftk::IObservable<double> > Viewport::observeTileZoom() const
+        {
+            return _p->tileZoom;
+        }
+
+        void Viewport::setTileZoom(double value)
+        {
+            FTK_P();
+            const double zoom = ftk::clamp(value, p.zoomRange.min(), p.zoomRange.max());
+            CompareOptions options = p.compareOptions->get();
+            const size_t count = std::max<size_t>(
+                1,
+                std::max(p.videoFrame.size(), p.activeTile + 1));
+            if (options.tileZoomSync)
+            {
+                options.tileZooms.assign(count, zoom);
+            }
+            else
+            {
+                options.tileZooms.resize(count, 1.0);
+                options.tileZooms[p.activeTile] = zoom;
+            }
+            setCompareOptions(options);
+        }
+
+        bool Viewport::isTileZoomSync() const
+        {
+            return _p->compareOptions->get().tileZoomSync;
+        }
+
+        void Viewport::setTileZoomSync(bool value)
+        {
+            FTK_P();
+            CompareOptions options = p.compareOptions->get();
+            if (value != options.tileZoomSync)
+            {
+                if (value)
+                {
+                    const double zoom = tl::getTileZoom(options, p.activeTile);
+                    const size_t count = std::max<size_t>(
+                        1,
+                        std::max(p.videoFrame.size(), p.activeTile + 1));
+                    options.tileZooms.assign(count, zoom);
+                }
+                options.tileZoomSync = value;
+                setCompareOptions(options);
+            }
+        }
+
         bool Viewport::hasFrameView() const
         {
             return _p->frameView->get();
@@ -480,21 +544,42 @@ namespace tl
         void Viewport::resetZoom()
         {
             FTK_P();
-            setZoom(1.F, _getViewportCenter());
+            if (Compare::Tile == p.compareOptions->get().compare)
+            {
+                setTileZoom(1.0);
+            }
+            else
+            {
+                setZoom(1.F, _getViewportCenter());
+            }
         }
 
         void Viewport::zoomIn()
         {
             FTK_P();
-            setZoom(
-                p.zoom->get() * 2.0,
-                p.mouse.inside ? p.mouse.pos : _getViewportCenter());
+            if (Compare::Tile == p.compareOptions->get().compare)
+            {
+                setTileZoom(p.tileZoom->get() * 2.0);
+            }
+            else
+            {
+                setZoom(
+                    p.zoom->get() * 2.0,
+                    p.mouse.inside ? p.mouse.pos : _getViewportCenter());
+            }
         }
 
         void Viewport::zoomOut()
         {
             FTK_P();
-            setZoom(p.zoom->get() / 2.0, _getViewportCenter());
+            if (Compare::Tile == p.compareOptions->get().compare)
+            {
+                setTileZoom(p.tileZoom->get() / 2.0);
+            }
+            else
+            {
+                setZoom(p.zoom->get() / 2.0, _getViewportCenter());
+            }
         }
 
         const ftk::RangeD& Viewport::getZoomRange() const
@@ -829,6 +914,7 @@ namespace tl
 
                 const ftk::Box2I& g = getGeometry();
                 p.mouse.pos = event.pos - g.min;
+                _updateActiveTile(p.mouse.pos);
 
                 switch (p.mouse.mode)
                 {
@@ -890,6 +976,7 @@ namespace tl
                 const ftk::Box2I& g = getGeometry();
                 p.mouse.pos = event.pos - g.min;
                 p.mouse.press = p.mouse.pos;
+                _updateActiveTile(p.mouse.pos);
 
                 if (p.panBinding.first == event.button &&
                     ftk::checkKeyModifier(p.panBinding.second, event.modifiers))
@@ -927,13 +1014,24 @@ namespace tl
 
                     const ftk::Box2I& g = getGeometry();
                     p.mouse.pos = event.pos - g.min;
+                    _updateActiveTile(p.mouse.pos);
 
-                    const double zoom = p.zoom->get();
+                    const bool tile =
+                        Compare::Tile == p.compareOptions->get().compare;
+                    const double zoom =
+                        tile ? p.tileZoom->get() : p.zoom->get();
                     const double newZoom =
                         event.value.y > 0 ?
                         zoom * p.mouseWheelScale :
                         zoom / p.mouseWheelScale;
-                    setZoom(newZoom, p.mouse.pos);
+                    if (tile)
+                    {
+                        setTileZoom(newZoom);
+                    }
+                    else
+                    {
+                        setZoom(newZoom, p.mouse.pos);
+                    }
                 }
                 else if (event.modifiers & static_cast<int>(ftk::KeyModifier::Control))
                 {
@@ -955,6 +1053,7 @@ namespace tl
             {
                 const ftk::Box2I& g = getGeometry();
                 p.mouse.pos = event.pos - g.min;
+                _updateActiveTile(p.mouse.pos);
 
                 if (0 == event.modifiers)
                 {
@@ -962,17 +1061,38 @@ namespace tl
                     {
                     case ftk::Key::_0:
                         event.accept = true;
-                        setZoom(1.0, p.mouse.pos);
+                        if (Compare::Tile == p.compareOptions->get().compare)
+                        {
+                            setTileZoom(1.0);
+                        }
+                        else
+                        {
+                            setZoom(1.0, p.mouse.pos);
+                        }
                         break;
 
                     case ftk::Key::Equals:
                         event.accept = true;
-                        setZoom(p.zoom->get() * 2.0, p.mouse.pos);
+                        if (Compare::Tile == p.compareOptions->get().compare)
+                        {
+                            setTileZoom(p.tileZoom->get() * 2.0);
+                        }
+                        else
+                        {
+                            setZoom(p.zoom->get() * 2.0, p.mouse.pos);
+                        }
                         break;
 
                     case ftk::Key::Minus:
                         event.accept = true;
-                        setZoom(p.zoom->get() / 2.0, p.mouse.pos);
+                        if (Compare::Tile == p.compareOptions->get().compare)
+                        {
+                            setTileZoom(p.tileZoom->get() / 2.0);
+                        }
+                        else
+                        {
+                            setZoom(p.zoom->get() / 2.0, p.mouse.pos);
+                        }
                         break;
 
                     case ftk::Key::Backspace:
@@ -989,6 +1109,41 @@ namespace tl
         void Viewport::keyReleaseEvent(ftk::KeyEvent& event)
         {
             event.accept = true;
+        }
+
+        void Viewport::_updateActiveTile(const ftk::V2I& widgetPos)
+        {
+            FTK_P();
+            const auto& options = p.compareOptions->get();
+            if (Compare::Tile != options.compare || p.videoFrame.empty())
+            {
+                return;
+            }
+
+            const ftk::V2I& viewPos = p.viewPos->get();
+            const double zoom = p.zoom->get();
+            const ftk::V2I renderPos(
+                std::lround((widgetPos.x - viewPos.x) / zoom),
+                std::lround((widgetPos.y - viewPos.y) / zoom));
+            const auto& displayOptions = p.displayOptions->get();
+            const auto bounds = getBounds(
+                options,
+                !displayOptions.empty() ?
+                    displayOptions.front().aspectRatio :
+                    AspectRatioOptions(),
+                p.videoFrame);
+            for (size_t i = 0; i < bounds.size(); ++i)
+            {
+                if (ftk::contains(bounds[i], renderPos))
+                {
+                    if (i != p.activeTile)
+                    {
+                        p.activeTile = i;
+                        p.tileZoom->setIfChanged(tl::getTileZoom(options, i));
+                    }
+                    break;
+                }
+            }
         }
 
         bool Viewport::_isMouseInside() const

--- a/lib/tlRender/UI/Viewport.h
+++ b/lib/tlRender/UI/Viewport.h
@@ -141,6 +141,21 @@ namespace tl
             //! Set the view zoom.
             TL_API void setZoom(double, const ftk::V2I& focus = ftk::V2I());
 
+            //! Get the zoom for the active tile.
+            TL_API double getTileZoom() const;
+
+            //! Observe the zoom for the active tile.
+            TL_API std::shared_ptr<ftk::IObservable<double> > observeTileZoom() const;
+
+            //! Set the zoom for the active tile, or all tiles when synchronized.
+            TL_API void setTileZoom(double);
+
+            //! Get whether tile zoom is synchronized.
+            TL_API bool isTileZoomSync() const;
+
+            //! Set whether tile zoom is synchronized.
+            TL_API void setTileZoomSync(bool);
+
             //! Get the view zoom range.
             TL_API const ftk::RangeD& getZoomRange() const;
 
@@ -239,6 +254,7 @@ namespace tl
             ftk::Size2I _getRenderSize() const;
             ftk::V2I _getViewportCenter() const;
             void _frameView();
+            void _updateActiveTile(const ftk::V2I&);
 
             FTK_PRIVATE();
         };


### PR DESCRIPTION
## Summary
- persist one zoom value per comparison tile, with synchronized zoom enabled by default
- route wheel, keyboard, and reset zoom actions to the tile under the pointer in tile comparison mode
- apply tile zoom during video rendering while leaving the other comparison modes unchanged
- preserve compatibility with older serialized comparison options

## Verification
- `git diff --check`
- changed sources compiled with the Visual Studio project files:
  - `tlGL`: `RenderVideo.cpp`
  - `tlUI`: `Viewport.cpp`
  - `tlTimeline`: `CompareOptions.cpp`
- focused unit coverage added in `CompareOptionsTest.cpp` for zoom lookup, geometry, JSON round-trip, and legacy JSON defaults

## Local test limitation
The complete local build currently reaches unrelated errors in existing OpenTimelineIO/nlohmann integration sources (`ItemOptions.cpp`, `ThumbnailSystem.cpp`, and `PlayerPrivate.cpp`). The object files for every source changed by this PR were produced before those baseline failures.