### PR TITLE
Add cancellable timeline initialization

### DIFF
--- a/lib/tlRender/IO/FFmpegRead.cpp
+++ b/lib/tlRender/IO/FFmpegRead.cpp
@@ -19,6 +19,12 @@ namespace tl
 {
     namespace ffmpeg
     {
+        int avIOInterrupt(void* opaque)
+        {
+            const auto cancelled = static_cast<std::atomic_bool*>(opaque);
+            return cancelled && cancelled->load(std::memory_order_acquire) ? 1 : 0;
+        }
+
         AVIOBufferData::AVIOBufferData(const uint8_t* p, size_t size) :
             p(p),
             size(size)
@@ -184,13 +190,15 @@ namespace tl
                 [this, path]
                 {
                     FTK_P();
+                    _bindIOCancellation();
                     try
                     {
                         p.readVideo = std::make_shared<ReadVideo>(
                             getFileName(path),
                             _mem,
                             p.options,
-                            _logSystem.lock());
+                            _logSystem.lock(),
+                            _getIOCancellationFlag());
                         const auto& videoInfo = p.readVideo->getInfo();
                         if (videoInfo.isValid())
                         {
@@ -220,6 +228,7 @@ namespace tl
 
                     // The epilogue.
                     p.condition.stopQueues();
+                    _unbindIOCancellation();
                 });
         }
 
@@ -230,7 +239,7 @@ namespace tl
         VideoRead::~VideoRead()
         {
             FTK_P();
-
+            cancelIO();
             // Stop the condition and wake the thread so that shutdown does
             // not have to wait for the request timeout.
             p.condition.stop();
@@ -411,12 +420,14 @@ namespace tl
                 [this, path]
                 {
                     FTK_P();
+                    _bindIOCancellation();
                     try
                     {
                         p.readAudio = std::make_shared<ReadAudio>(
                             getFileName(path),
                             _mem,
-                            p.options);
+                            p.options,
+                            _getIOCancellationFlag());
                         p.info.audio = p.readAudio->getInfo();
                         p.info.audioTime = p.readAudio->getTimeRange();
                         p.info.tags = p.readAudio->getTags();
@@ -452,6 +463,7 @@ namespace tl
 
                     // The epilogue.
                     p.condition.stopQueues();
+                    _unbindIOCancellation();
                 });
         }
 
@@ -463,6 +475,7 @@ namespace tl
         {
             FTK_P();
 
+            cancelIO();
             // Stop the condition and wake the thread so that shutdown does
             // not have to wait for the request timeout.
             p.condition.stop();

--- a/lib/tlRender/IO/FFmpegReadAudio.cpp
+++ b/lib/tlRender/IO/FFmpegReadAudio.cpp
@@ -14,9 +14,11 @@ namespace tl
         ReadAudio::ReadAudio(
             const std::string& fileName,
             const std::vector<ftk::MemFile>& memory,
-            const ReadOptions& options) :
+            const ReadOptions& options,
+            const std::shared_ptr<std::atomic_bool>& cancellation) :
             _fileName(fileName),
-            _options(options)
+            _options(options),
+            _cancellation(cancellation)
         {
             try
             {
@@ -50,9 +52,20 @@ namespace tl
                     _avFormatContext->pb = _avIOContext;
                 }
 
+                if (!_avFormatContext)
+                {
+                    _avFormatContext = avformat_alloc_context();
+                    if (!_avFormatContext)
+                    {
+                        throw std::runtime_error(ftk::Format("Cannot allocate format context: \"{0}\"").arg(fileName));
+                    }
+                }
+                _avFormatContext->interrupt_callback.callback = avIOInterrupt;
+                _avFormatContext->interrupt_callback.opaque = _cancellation.get();
+
                 int r = avformat_open_input(
                     &_avFormatContext,
-                    !_avFormatContext ? fileName.c_str() : nullptr,
+                    memory.empty() ? fileName.c_str() : nullptr,
                     nullptr,
                     nullptr);
                 if (r < 0)

--- a/lib/tlRender/IO/FFmpegReadPrivate.h
+++ b/lib/tlRender/IO/FFmpegReadPrivate.h
@@ -25,6 +25,8 @@ namespace tl
 {
     namespace ffmpeg
     {
+        int avIOInterrupt(void*);
+
         struct AVIOBufferData
         {
             AVIOBufferData() = default;
@@ -64,7 +66,8 @@ namespace tl
                 const std::string& fileName,
                 const std::vector<ftk::MemFile>& memory,
                 const ReadOptions& options,
-                const std::shared_ptr<ftk::LogSystem>& logSystem);
+                const std::shared_ptr<ftk::LogSystem>& logSystem,
+                const std::shared_ptr<std::atomic_bool>& cancellation);
 
             ~ReadVideo();
 
@@ -120,6 +123,7 @@ namespace tl
             bool _hwAccel = false;
             bool _hwLogged = false;
             std::weak_ptr<ftk::LogSystem> _logSystem;
+            std::shared_ptr<std::atomic_bool> _cancellation;
             std::list<std::shared_ptr<ftk::Image> > _buffer;
             bool _eof = false;
             size_t _errorCount = 0;
@@ -132,7 +136,8 @@ namespace tl
             ReadAudio(
                 const std::string& fileName,
                 const std::vector<ftk::MemFile>&,
-                const ReadOptions&);
+                const ReadOptions&,
+                const std::shared_ptr<std::atomic_bool>& cancellation);
 
             ~ReadAudio();
 
@@ -175,6 +180,7 @@ namespace tl
             std::map<int, AVCodecContext*> _avCodecContext;
             AVFrame* _avFrame = nullptr;
             SwrContext* _swrContext = nullptr;
+            std::shared_ptr<std::atomic_bool> _cancellation;
             std::list<std::shared_ptr<Audio> > _buffer;
             bool _eof = false;
             size_t _errorCount = 0;

--- a/lib/tlRender/IO/FFmpegReadVideo.cpp
+++ b/lib/tlRender/IO/FFmpegReadVideo.cpp
@@ -23,10 +23,12 @@ namespace tl
             const std::string& fileName,
             const std::vector<ftk::MemFile>& memory,
             const ReadOptions& options,
-            const std::shared_ptr<ftk::LogSystem>& logSystem) :
+            const std::shared_ptr<ftk::LogSystem>& logSystem,
+            const std::shared_ptr<std::atomic_bool>& cancellation) :
             _fileName(fileName),
             _options(options),
-            _logSystem(logSystem)
+            _logSystem(logSystem),
+            _cancellation(cancellation)
         {
             try
             {
@@ -60,9 +62,20 @@ namespace tl
                     _avFormatContext->pb = _avIOContext;
                 }
 
+                if (!_avFormatContext)
+                {
+                    _avFormatContext = avformat_alloc_context();
+                    if (!_avFormatContext)
+                    {
+                        throw std::runtime_error(ftk::Format("Cannot allocate format context: \"{0}\"").arg(fileName));
+                    }
+                }
+                _avFormatContext->interrupt_callback.callback = avIOInterrupt;
+                _avFormatContext->interrupt_callback.opaque = _cancellation.get();
+
                 int r = avformat_open_input(
                     &_avFormatContext,
-                    !_avFormatContext ? fileName.c_str() : nullptr,
+                    memory.empty() ? fileName.c_str() : nullptr,
                     nullptr,
                     nullptr);
                 if (r < 0)

--- a/lib/tlRender/IO/Read.cpp
+++ b/lib/tlRender/IO/Read.cpp
@@ -5,8 +5,36 @@
 
 #include <ftk/Core/LogSystem.h>
 
+#include <mutex>
+#include <vector>
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
 namespace tl
 {
+    struct IRead::CancellationState
+    {
+        std::shared_ptr<std::atomic_bool> cancelled =
+            std::make_shared<std::atomic_bool>(false);
+#if defined(_WIN32)
+        struct ThreadHandle
+        {
+            DWORD id = 0;
+            HANDLE handle = nullptr;
+        };
+        std::mutex mutex;
+        std::vector<ThreadHandle> threads;
+#endif
+    };
+
     void IRead::_init(
         const ftk::Path& path,
         const std::vector<ftk::MemFile>& mem,
@@ -17,11 +45,96 @@ namespace tl
         _mem = mem;
     }
 
-    IRead::IRead()
+    IRead::IRead() :
+        _cancellation(std::make_shared<CancellationState>())
     {}
 
     IRead::~IRead()
-    {}
+    {
+        cancelIO();
+#if defined(_WIN32)
+        std::lock_guard<std::mutex> lock(_cancellation->mutex);
+        for (const auto& i : _cancellation->threads)
+        {
+            if (i.handle)
+            {
+                CloseHandle(i.handle);
+            }
+        }
+        _cancellation->threads.clear();
+#endif
+    }
+
+    void IRead::cancelIO()
+    {
+        _cancellation->cancelled->store(true, std::memory_order_release);
+#if defined(_WIN32)
+        std::lock_guard<std::mutex> lock(_cancellation->mutex);
+        for (const auto& i : _cancellation->threads)
+        {
+            if (i.handle)
+            {
+                CancelSynchronousIo(i.handle);
+            }
+        }
+#endif
+    }
+
+    bool IRead::isIOCancellationRequested() const
+    {
+        return _cancellation->cancelled->load(std::memory_order_acquire);
+    }
+
+    void IRead::_bindIOCancellation()
+    {
+#if defined(_WIN32)
+        HANDLE duplicate = nullptr;
+        if (!DuplicateHandle(
+            GetCurrentProcess(),
+            GetCurrentThread(),
+            GetCurrentProcess(),
+            &duplicate,
+            0,
+            FALSE,
+            DUPLICATE_SAME_ACCESS))
+        {
+            return;
+        }
+        const DWORD id = GetCurrentThreadId();
+        std::lock_guard<std::mutex> lock(_cancellation->mutex);
+        _cancellation->threads.push_back({ id, duplicate });
+        if (_cancellation->cancelled->load(std::memory_order_acquire))
+        {
+            CancelSynchronousIo(duplicate);
+        }
+#endif
+    }
+
+    void IRead::_unbindIOCancellation()
+    {
+#if defined(_WIN32)
+        const DWORD id = GetCurrentThreadId();
+        std::lock_guard<std::mutex> lock(_cancellation->mutex);
+        for (auto i = _cancellation->threads.begin();
+            i != _cancellation->threads.end(); ++i)
+        {
+            if (i->id == id)
+            {
+                if (i->handle)
+                {
+                    CloseHandle(i->handle);
+                }
+                _cancellation->threads.erase(i);
+                break;
+            }
+        }
+#endif
+    }
+
+    const std::shared_ptr<std::atomic_bool>& IRead::_getIOCancellationFlag() const
+    {
+        return _cancellation->cancelled;
+    }
 
     std::string IRead::getError() const
     {

--- a/lib/tlRender/IO/Read.h
+++ b/lib/tlRender/IO/Read.h
@@ -6,6 +6,9 @@
 #include <tlRender/IO/Decode.h>
 #include <tlRender/IO/Plugin.h>
 
+#include <atomic>
+#include <memory>
+
 namespace tl
 {
     //! Base class for readers.
@@ -28,6 +31,13 @@ namespace tl
     public:
         TL_API virtual ~IRead();
 
+        //! Irreversibly cancel blocking I/O owned by this reader. Unlike
+        //! cancelRequests(), this is intended for initialization or shutdown.
+        TL_API void cancelIO();
+
+        //! Whether blocking I/O cancellation has been requested.
+        TL_API bool isIOCancellationRequested() const;
+
         //! Get the information.
         TL_API virtual std::future<IOInfo> getInfo() = 0;
 
@@ -44,7 +54,18 @@ namespace tl
         TL_API virtual size_t getErrorCount() const;
 
     protected:
+        //! Bind/unbind a worker so Windows synchronous filesystem I/O can be
+        //! interrupted during cancellation. These calls are no-ops elsewhere.
+        void _bindIOCancellation();
+        void _unbindIOCancellation();
+
+        const std::shared_ptr<std::atomic_bool>& _getIOCancellationFlag() const;
+
         std::vector<ftk::MemFile> _mem;
+
+    private:
+        struct CancellationState;
+        std::shared_ptr<CancellationState> _cancellation;
     };
 
     //! Base class for video readers.

--- a/lib/tlRender/IOTest/IOTest.cpp
+++ b/lib/tlRender/IOTest/IOTest.cpp
@@ -33,6 +33,7 @@ namespace tl
 
         void IOTest::run()
         {
+            _cancellation();
             _videoData();
             _ioSystem();
             _decode();
@@ -40,6 +41,35 @@ namespace tl
             _missingFrames();
             _seqRange();
             _structural();
+        }
+
+        namespace
+        {
+            class CancellationRead : public IRead
+            {
+            public:
+                std::future<IOInfo> getInfo() override
+                {
+                    std::promise<IOInfo> promise;
+                    promise.set_value(IOInfo());
+                    return promise.get_future();
+                }
+
+                void cancelRequests() override
+                {}
+            };
+        }
+
+        void IOTest::_cancellation()
+        {
+            CancellationRead read;
+            FTK_ASSERT(!read.isIOCancellationRequested());
+            read.cancelIO();
+            FTK_ASSERT(read.isIOCancellationRequested());
+
+            // Cancellation is irreversible and safe to request repeatedly.
+            read.cancelIO();
+            FTK_ASSERT(read.isIOCancellationRequested());
         }
 
         void IOTest::_videoData()

--- a/lib/tlRender/IOTest/IOTest.h
+++ b/lib/tlRender/IOTest/IOTest.h
@@ -20,6 +20,7 @@ namespace tl
             void run() override;
 
         private:
+            void _cancellation();
             void _videoData();
             void _ioSystem();
             void _decode();

--- a/lib/tlRender/Timeline/CMakeLists.txt
+++ b/lib/tlRender/Timeline/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCE
     System.cpp
     TimeUnits.cpp
     Timeline.cpp
+    TimelineCancellation.cpp
     TimelineOptions.cpp
     Transition.cpp
     Util.cpp

--- a/lib/tlRender/Timeline/Timeline.cpp
+++ b/lib/tlRender/Timeline/Timeline.cpp
@@ -292,9 +292,15 @@ namespace tl
         const std::shared_ptr<ftk::Context>& context,
         const ftk::Path& inputPath,
         const ftk::Path& inputAudioPath,
-        const Options& options)
+        const Options& options,
+        const std::shared_ptr<TimelineInitCancellation>& cancellation)
     {
         FTK_P();
+
+        if (cancellation && cancellation->isCancelled())
+        {
+            throw std::runtime_error("Timeline initialization cancelled");
+        }
 
         ftk::Path path = inputPath;
         ftk::Path audioPath = inputAudioPath;
@@ -348,8 +354,16 @@ namespace tl
         {
             if (auto decode = plugin->decode(options.ioOptions))
             {
+                if (cancellation && cancellation->isCancelled())
+                {
+                    throw std::runtime_error("Timeline initialization cancelled");
+                }
                 info = SeqDecode::create(
                     path, {}, decode, options.ioOptions)->getInfo();
+                if (cancellation && cancellation->isCancelled())
+                {
+                    throw std::runtime_error("Timeline initialization cancelled");
+                }
                 infoValid = true;
             }
         }
@@ -360,31 +374,57 @@ namespace tl
             // timeline goes on to read is decided by the tracks below.
             auto videoRead = ioSystem->videoRead(path, options.ioOptions);
             auto audioRead = ioSystem->audioRead(path, options.ioOptions);
-            std::future<IOInfo> videoFuture;
-            std::future<IOInfo> audioFuture;
-            if (videoRead)
+            if (cancellation)
             {
-                videoFuture = videoRead->getInfo();
+                cancellation->_bind(videoRead);
+                cancellation->_bind(audioRead);
             }
-            if (audioRead)
+            try
             {
-                audioFuture = audioRead->getInfo();
+                std::future<IOInfo> videoFuture;
+                std::future<IOInfo> audioFuture;
+                if (videoRead)
+                {
+                    videoFuture = videoRead->getInfo();
+                }
+                if (audioRead)
+                {
+                    audioFuture = audioRead->getInfo();
+                }
+                IOInfo videoInfo;
+                if (videoFuture.valid())
+                {
+                    videoInfo = videoFuture.get();
+                    infoValid = true;
+                }
+                IOInfo audioInfo;
+                if (audioFuture.valid())
+                {
+                    audioInfo = audioFuture.get();
+                    infoValid = true;
+                }
+                if (infoValid)
+                {
+                    info = merge(videoInfo, audioInfo);
+                }
             }
-            IOInfo videoInfo;
-            if (videoFuture.valid())
+            catch (...)
             {
-                videoInfo = videoFuture.get();
-                infoValid = true;
+                if (cancellation)
+                {
+                    cancellation->_unbind(videoRead);
+                    cancellation->_unbind(audioRead);
+                }
+                throw;
             }
-            IOInfo audioInfo;
-            if (audioFuture.valid())
+            if (cancellation)
             {
-                audioInfo = audioFuture.get();
-                infoValid = true;
+                cancellation->_unbind(videoRead);
+                cancellation->_unbind(audioRead);
             }
-            if (infoValid)
+            if (cancellation && cancellation->isCancelled())
             {
-                info = merge(videoInfo, audioInfo);
+                throw std::runtime_error("Timeline initialization cancelled");
             }
         }
         if (infoValid)
@@ -508,7 +548,22 @@ namespace tl
             {
                 if (auto audioRead = ioSystem->audioRead(audioPath, options.ioOptions))
                 {
-                    const auto audioInfo = audioRead->getInfo().get();
+                    if (cancellation) cancellation->_bind(audioRead);
+                    IOInfo audioInfo;
+                    try
+                    {
+                        audioInfo = audioRead->getInfo().get();
+                    }
+                    catch (...)
+                    {
+                        if (cancellation) cancellation->_unbind(audioRead);
+                        throw;
+                    }
+                    if (cancellation) cancellation->_unbind(audioRead);
+                    if (cancellation && cancellation->isCancelled())
+                    {
+                        throw std::runtime_error("Timeline initialization cancelled");
+                    }
 
                     auto audioClip = new OTIO_NS::Clip;
                     audioClip->set_source_range(audioInfo.audioTime);
@@ -710,13 +765,14 @@ namespace tl
         dict["audioPath"] = audioPath.get();
         otioTimeline->metadata()["tlRender"] = dict;
 
-        _init(context, otioTimeline, options);
+        _init(context, otioTimeline, options, cancellation);
     }
 
     void Timeline::_init(
         const std::shared_ptr<ftk::Context>& context,
         const OTIO_NS::SerializableObject::Retainer<OTIO_NS::Timeline>& otioTimeline,
-        const Options& options)
+        const Options& options,
+        const std::shared_ptr<TimelineInitCancellation>& cancellation)
     {
         FTK_P();
 
@@ -773,6 +829,11 @@ namespace tl
             {}
         }
         p.options = options;
+        p.initCancellation = cancellation;
+        if (p.initCancellation && p.initCancellation->isCancelled())
+        {
+            throw std::runtime_error("Timeline initialization cancelled");
+        }
         p.videoReadCache.setMax(p.options.readCacheMax);
         p.audioReadCache.setMax(p.options.readCacheMax);
         p.seqCache.setMax(p.options.seqCacheMax);
@@ -910,6 +971,11 @@ namespace tl
             arg(p.ioInfo.audio.type).
             arg(p.ioInfo.audio.sampleRate));
 
+        if (p.initCancellation && p.initCancellation->isCancelled())
+        {
+            throw std::runtime_error("Timeline initialization cancelled");
+        }
+
         // Create a new thread.
         p.thread.running = true;
         p.thread.logTimer = std::chrono::steady_clock::now();
@@ -926,6 +992,7 @@ namespace tl
                     _finishRequests();
                 });
         }
+        p.initCancellation.reset();
     }
 
     namespace
@@ -969,17 +1036,18 @@ namespace tl
         const Options& options)
     {
         auto out = std::shared_ptr<Timeline>(new Timeline);
-        out->_init(context, timeline, options);
+        out->_init(context, timeline, options, nullptr);
         return out;
     }
 
     std::shared_ptr<Timeline> Timeline::create(
         const std::shared_ptr<ftk::Context>& context,
         const ftk::Path& path,
-        const Options& options)
+        const Options& options,
+        const std::shared_ptr<TimelineInitCancellation>& cancellation)
     {
         auto out = std::shared_ptr<Timeline>(new Timeline);
-        out->_init(context, path, ftk::Path(), options);
+        out->_init(context, path, ftk::Path(), options, cancellation);
         return out;
     }
 
@@ -987,10 +1055,11 @@ namespace tl
         const std::shared_ptr<ftk::Context>& context,
         const ftk::Path& path,
         const ftk::Path& audioPath,
-        const Options& options)
+        const Options& options,
+        const std::shared_ptr<TimelineInitCancellation>& cancellation)
     {
         auto out = std::shared_ptr<Timeline>(new Timeline);
-        out->_init(context, path, audioPath, options);
+        out->_init(context, path, audioPath, options, cancellation);
         return out;
     }
 
@@ -1004,7 +1073,8 @@ namespace tl
             context,
             ftk::Path(fileName, options.pathOptions),
             ftk::Path(),
-            options);
+            options,
+            nullptr);
         return out;
     }
 
@@ -1019,7 +1089,8 @@ namespace tl
             context,
             ftk::Path(fileName, options.pathOptions),
             ftk::Path(audioFileName, options.pathOptions),
-            options);
+            options,
+            nullptr);
         return out;
     }
 
@@ -1963,14 +2034,46 @@ namespace tl
         const IOOptions& ioOptions,
         IOInfo& out)
     {
+        FTK_P();
         if (auto seq = _getSeqDecode(mediaReference, ioOptions))
         {
+            if (p.initCancellation && p.initCancellation->isCancelled())
+            {
+                throw std::runtime_error("Timeline initialization cancelled");
+            }
             out = seq->getInfo();
+            if (p.initCancellation && p.initCancellation->isCancelled())
+            {
+                throw std::runtime_error("Timeline initialization cancelled");
+            }
             return true;
         }
         if (auto videoRead = _getVideoRead(mediaReference, ioOptions))
         {
-            out = videoRead->getInfo().get();
+            if (p.initCancellation)
+            {
+                p.initCancellation->_bind(videoRead);
+            }
+            try
+            {
+                out = videoRead->getInfo().get();
+            }
+            catch (...)
+            {
+                if (p.initCancellation)
+                {
+                    p.initCancellation->_unbind(videoRead);
+                }
+                throw;
+            }
+            if (p.initCancellation)
+            {
+                p.initCancellation->_unbind(videoRead);
+                if (p.initCancellation->isCancelled())
+                {
+                    throw std::runtime_error("Timeline initialization cancelled");
+                }
+            }
             return true;
         }
         return false;
@@ -1981,10 +2084,34 @@ namespace tl
         const IOOptions& ioOptions,
         IOInfo& out)
     {
+        FTK_P();
         // Audio is never a sequence of stateless files.
         if (auto audioRead = _getAudioRead(mediaReference, ioOptions))
         {
-            out = audioRead->getInfo().get();
+            if (p.initCancellation)
+            {
+                p.initCancellation->_bind(audioRead);
+            }
+            try
+            {
+                out = audioRead->getInfo().get();
+            }
+            catch (...)
+            {
+                if (p.initCancellation)
+                {
+                    p.initCancellation->_unbind(audioRead);
+                }
+                throw;
+            }
+            if (p.initCancellation)
+            {
+                p.initCancellation->_unbind(audioRead);
+                if (p.initCancellation->isCancelled())
+                {
+                    throw std::runtime_error("Timeline initialization cancelled");
+                }
+            }
             return true;
         }
         return false;
@@ -1995,40 +2122,80 @@ namespace tl
         const IOOptions& ioOptions,
         IOInfo& out)
     {
+        FTK_P();
         if (auto seq = _getSeqDecode(mediaReference, ioOptions))
         {
+            if (p.initCancellation && p.initCancellation->isCancelled())
+            {
+                throw std::runtime_error("Timeline initialization cancelled");
+            }
             out = seq->getInfo();
+            if (p.initCancellation && p.initCancellation->isCancelled())
+            {
+                throw std::runtime_error("Timeline initialization cancelled");
+            }
             return true;
         }
         // Both requests go out before either is waited on, so that the two
         // readers open the file at the same time.
         auto videoRead = _getVideoRead(mediaReference, ioOptions);
         auto audioRead = _getAudioRead(mediaReference, ioOptions);
-        std::future<IOInfo> videoFuture;
-        std::future<IOInfo> audioFuture;
-        if (videoRead)
+        if (p.initCancellation)
         {
-            videoFuture = videoRead->getInfo();
+            p.initCancellation->_bind(videoRead);
+            p.initCancellation->_bind(audioRead);
         }
-        if (audioRead)
+        try
         {
-            audioFuture = audioRead->getInfo();
+            std::future<IOInfo> videoFuture;
+            std::future<IOInfo> audioFuture;
+            if (videoRead)
+            {
+                videoFuture = videoRead->getInfo();
+            }
+            if (audioRead)
+            {
+                audioFuture = audioRead->getInfo();
+            }
+            if (!videoFuture.valid() && !audioFuture.valid())
+            {
+                if (p.initCancellation)
+                {
+                    p.initCancellation->_unbind(videoRead);
+                    p.initCancellation->_unbind(audioRead);
+                }
+                return false;
+            }
+            IOInfo videoInfo;
+            if (videoFuture.valid())
+            {
+                videoInfo = videoFuture.get();
+            }
+            IOInfo audioInfo;
+            if (audioFuture.valid())
+            {
+                audioInfo = audioFuture.get();
+            }
+            out = merge(videoInfo, audioInfo);
         }
-        if (!videoFuture.valid() && !audioFuture.valid())
+        catch (...)
         {
-            return false;
+            if (p.initCancellation)
+            {
+                p.initCancellation->_unbind(videoRead);
+                p.initCancellation->_unbind(audioRead);
+            }
+            throw;
         }
-        IOInfo videoInfo;
-        if (videoFuture.valid())
+        if (p.initCancellation)
         {
-            videoInfo = videoFuture.get();
+            p.initCancellation->_unbind(videoRead);
+            p.initCancellation->_unbind(audioRead);
+            if (p.initCancellation->isCancelled())
+            {
+                throw std::runtime_error("Timeline initialization cancelled");
+            }
         }
-        IOInfo audioInfo;
-        if (audioFuture.valid())
-        {
-            audioInfo = audioFuture.get();
-        }
-        out = merge(videoInfo, audioInfo);
         return true;
     }
 

--- a/lib/tlRender/Timeline/Timeline.h
+++ b/lib/tlRender/Timeline/Timeline.h
@@ -26,6 +26,26 @@ namespace ftk
 
 namespace tl
 {
+    //! Cancellation handle for timeline initialization. Cancellation is
+    //! irreversible and interrupts any readers currently probing media.
+    class TL_API_TYPE TimelineInitCancellation
+    {
+    public:
+        TL_API TimelineInitCancellation();
+        TL_API ~TimelineInitCancellation();
+
+        TL_API void cancel();
+        TL_API bool isCancelled() const;
+
+    private:
+        void _bind(const std::shared_ptr<IRead>&);
+        void _unbind(const std::shared_ptr<IRead>&);
+
+        struct Private;
+        std::unique_ptr<Private> _p;
+        friend class Timeline;
+    };
+
     //! Video request.
     struct TL_API_TYPE VideoRequest
     {
@@ -50,11 +70,13 @@ namespace tl
             const std::shared_ptr<ftk::Context>&,
             const ftk::Path& inputPath,
             const ftk::Path& inputAudioPath,
-            const Options&);
+            const Options&,
+            const std::shared_ptr<TimelineInitCancellation>&);
         void _init(
             const std::shared_ptr<ftk::Context>&,
             const OTIO_NS::SerializableObject::Retainer<OTIO_NS::Timeline>&,
-            const Options&);
+            const Options&,
+            const std::shared_ptr<TimelineInitCancellation>&);
 
         Timeline();
 
@@ -72,7 +94,8 @@ namespace tl
         TL_API static std::shared_ptr<Timeline> create(
             const std::shared_ptr<ftk::Context>&,
             const ftk::Path&,
-            const Options& = Options());
+            const Options& = Options(),
+            const std::shared_ptr<TimelineInitCancellation>& = nullptr);
 
         //! Create a new timeline from a path and audio path. The path can
         //! point to an .otio file, movie file, or image sequence.
@@ -80,7 +103,8 @@ namespace tl
             const std::shared_ptr<ftk::Context>&,
             const ftk::Path& path,
             const ftk::Path& audioPath,
-            const Options& = Options());
+            const Options& = Options(),
+            const std::shared_ptr<TimelineInitCancellation>& = nullptr);
 
         //! Create a new timeline from a file name. The file name can point
         //! to an .otio file, movie file, or image sequence.

--- a/lib/tlRender/Timeline/TimelineCancellation.cpp
+++ b/lib/tlRender/Timeline/TimelineCancellation.cpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the tlRender project.
+
+#include <tlRender/Timeline/Timeline.h>
+
+#include <tlRender/IO/Read.h>
+
+#include <algorithm>
+#include <atomic>
+#include <mutex>
+#include <vector>
+
+namespace tl
+{
+    struct TimelineInitCancellation::Private
+    {
+        std::atomic_bool cancelled{ false };
+        std::mutex mutex;
+        std::vector<std::shared_ptr<IRead> > reads;
+    };
+
+    TimelineInitCancellation::TimelineInitCancellation() :
+        _p(new Private)
+    {}
+
+    TimelineInitCancellation::~TimelineInitCancellation()
+    {
+        cancel();
+    }
+
+    void TimelineInitCancellation::cancel()
+    {
+        _p->cancelled.store(true, std::memory_order_release);
+        std::vector<std::shared_ptr<IRead> > reads;
+        {
+            std::lock_guard<std::mutex> lock(_p->mutex);
+            reads = _p->reads;
+        }
+        for (const auto& read : reads)
+        {
+            if (read)
+            {
+                read->cancelIO();
+            }
+        }
+    }
+
+    bool TimelineInitCancellation::isCancelled() const
+    {
+        return _p->cancelled.load(std::memory_order_acquire);
+    }
+
+    void TimelineInitCancellation::_bind(const std::shared_ptr<IRead>& read)
+    {
+        {
+            std::lock_guard<std::mutex> lock(_p->mutex);
+            if (read &&
+                std::find(_p->reads.begin(), _p->reads.end(), read) ==
+                _p->reads.end())
+            {
+                _p->reads.push_back(read);
+            }
+        }
+        if (isCancelled() && read)
+        {
+            read->cancelIO();
+        }
+    }
+
+    void TimelineInitCancellation::_unbind(const std::shared_ptr<IRead>& read)
+    {
+        std::lock_guard<std::mutex> lock(_p->mutex);
+        _p->reads.erase(
+            std::remove(_p->reads.begin(), _p->reads.end(), read),
+            _p->reads.end());
+    }
+}

--- a/lib/tlRender/Timeline/TimelinePrivate.h
+++ b/lib/tlRender/Timeline/TimelinePrivate.h
@@ -96,6 +96,9 @@ namespace tl
         ftk::Path path;
         ftk::Path audioPath;
         Options options;
+        // Present only while timeline metadata is being read. It can own
+        // both the video and audio probes used by the split reader model.
+        std::shared_ptr<TimelineInitCancellation> initCancellation;
         // Held while a caller drives an unthreaded timeline. _requests()
         // mutates the thread-owned lists without locking, on the assumption
         // that one thread runs it; without a thread that is whichever caller

--- a/lib/tlRender/TimelineTest/TimelineTest.cpp
+++ b/lib/tlRender/TimelineTest/TimelineTest.cpp
@@ -57,6 +57,7 @@ namespace tl
 
         void TimelineTest::run()
         {
+            _cancellation();
             _enums();
             _options();
             _util();
@@ -71,6 +72,18 @@ namespace tl
             _separateAudio();
             _spatial();
             _mediaReferences();
+        }
+
+        void TimelineTest::_cancellation()
+        {
+            TimelineInitCancellation cancellation;
+            FTK_ASSERT(!cancellation.isCancelled());
+            cancellation.cancel();
+            FTK_ASSERT(cancellation.isCancelled());
+
+            // Cancellation is irreversible and safe to request repeatedly.
+            cancellation.cancel();
+            FTK_ASSERT(cancellation.isCancelled());
         }
 
         void TimelineTest::_spatial()

--- a/lib/tlRender/TimelineTest/TimelineTest.h
+++ b/lib/tlRender/TimelineTest/TimelineTest.h
@@ -22,6 +22,7 @@ namespace tl
             void run() override;
 
         private:
+            void _cancellation();
             void _enums();
             void _options();
             void _util();


### PR DESCRIPTION
## Summary
- add an irreversible `TimelineInitCancellation` handle to interrupt timeline initialization
- propagate cancellation to active readers, FFmpeg interrupt callbacks, and Windows synchronous I/O
- keep the new cancellation argument optional so existing `Timeline::create()` callers remain source-compatible
- add focused cancellation coverage for readers and timeline initialization handles

## Testing
- CMake configure: Visual Studio 2022 / x64 / Release
- focused compilation passed for the changed `Read`, `SeqIORead`, FFmpeg, cancellation, and test translation units
- `git diff --check` passed

## Local build note
The complete local tlTimeline target is currently blocked by pre-existing OTIO/ftk compatibility errors around `RationalTime`/`TimeRange` stream formatting in unchanged code. The modified translation units were compiled independently; CI remains the authoritative clean dependency build.